### PR TITLE
fix : internal 경로 이름 변경 및 ResponseEntity 제거

### DIFF
--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  application:
+    name: notification-service
+
+  datasource:
+    url: jdbc:mysql://localhost:3307/notification_db
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+
+server:
+  port: 8081
+
+

--- a/organization-service/build.gradle
+++ b/organization-service/build.gradle
@@ -30,7 +30,7 @@ ext {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-//    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/organization-service/src/main/java/com/sparta/moim/organization/presentation/controller/OrganizationCheckRoleController.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/presentation/controller/OrganizationCheckRoleController.java
@@ -13,17 +13,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/organizations")
+@RequestMapping("/internal/v1/organizations")
 @RequiredArgsConstructor
 public class OrganizationCheckRoleController {
 
     private final OrganizationCheckRoleUseCase organizationCheckRoleUseCase;
 
     @GetMapping("/{organizationTrackingId}/members/{userTrackingId}/has-role")
-    public ResponseEntity<ApiResponseData<Boolean>> checkRole(
+    public ApiResponseData<Boolean> checkRole(
             @PathVariable String organizationTrackingId,
             @PathVariable String userTrackingId,
             @RequestParam List<OrganizationMemberRole> roles){
-        return ResponseEntity.ok(ApiResponseData.success(organizationCheckRoleUseCase.execute(organizationTrackingId,userTrackingId, roles)));
+        return ApiResponseData.success(organizationCheckRoleUseCase.execute(organizationTrackingId,userTrackingId, roles));
     }
 }

--- a/organization-service/src/main/resources/application.yml
+++ b/organization-service/src/main/resources/application.yml
@@ -17,3 +17,9 @@ spring:
       ddl-auto: update
     show-sql: true
 
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:19090/eureka/
+    register-with-eureka: true
+    fetch-registry: true

--- a/organization-service/src/main/resources/application.yml
+++ b/organization-service/src/main/resources/application.yml
@@ -1,0 +1,19 @@
+server:
+  port: 8084
+
+spring:
+  application:
+    name: organization-service
+
+  datasource:
+    url: jdbc:mysql://localhost:3310/organization_db
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
- eureka 서버에 Organization 등록
- 내부 통신 api url을 internal로 바뀜.
- 내부 통신 응답에 ResponseEntity 제거

### 2️⃣ 변경 이유
- Convention을 지키기 위함

### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - notification-service 및 organization-service에 대한 Spring Boot 애플리케이션 환경설정 파일이 추가되었습니다.
- **버그 수정**
    - organization-service에서 Eureka 클라이언트 라이브러리가 활성화되어 서비스 등록이 가능해졌습니다.
- **리팩터**
    - 조직 역할 확인 컨트롤러의 엔드포인트 경로가 변경되고, 반환 타입이 단순화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->