### PR TITLE
feat : 댓글을 삭제하는 feignclient api 생성

### DIFF
--- a/comment-service/src/main/java/com/sparta/moim/comment/domain/service/CommentDomainService.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/domain/service/CommentDomainService.java
@@ -15,6 +15,8 @@ import com.sparta.moim.common.security.CustomUserDetails;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -67,10 +69,23 @@ public class CommentDomainService {
 
   //특정 게시글의 특정 댓글 삭제
   //게시물이 삭제되면 댓글도 삭제되도록 처리 필요
-  public void deleteComment(String postId, UUID commentId){
+  public void deleteComment(String postId, UUID commentId, CustomUserDetails customUserDetails){
     Comment comment = commentRepository.findComment(postId,commentId).get();
-    comment.softDelete("testUsername");
+    comment.softDelete(customUserDetails.getTrackingId().toString());
     commentRepository.save(comment);
+
+  }
+
+  //특정 게시글의 전체 댓글 삭제
+  public void deleteComments(String postId, CustomUserDetails customUserDetails){
+    List<Comment> comments = commentRepository.findCommentAll(postId);
+    if(comments.isEmpty()){
+      throw new BaseException(NO_COMMENT_IN_POST);
+    }
+    for(Comment comment : comments) {
+      comment.softDelete(customUserDetails.getTrackingId().toString());
+      commentRepository.save(comment);
+    }
 
   }
 

--- a/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/feignclient/PostClient.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/feignclient/PostClient.java
@@ -1,13 +1,12 @@
 package com.sparta.moim.comment.infrastructure.feignclient;
 
 import com.sparta.moim.comment.infrastructure.feignclient.dto.ValidationResponse;
-import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient("post-service")
+@FeignClient(name = "post-service")
 public interface PostClient {
   @GetMapping("/internal/v1/posts/feeds/{id}")
-  ValidationResponse isValidFeed(@PathVariable final String id);
+  ValidationResponse isValidFeed(@PathVariable("id") final String id);
 }

--- a/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/response/CommentCode.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/response/CommentCode.java
@@ -11,8 +11,8 @@ public enum CommentCode implements Code {
   COMMENT_DELETE(HttpStatus.OK, "CM202", "댓글을 성공적으로 삭제하였습니다."),
   COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "CM400", "댓글을 찾을 수 없습니다."),
   POST_NOT_FOUND(HttpStatus.NOT_FOUND,"CM401", "해당 게시글은 존재하지 않습니다"),
-  COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CM401", "댓글 접근권한이 존재하지 않습니다.");
-
+  COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "CM401", "댓글 접근권한이 존재하지 않습니다."),
+  NO_COMMENT_IN_POST(HttpStatus.FORBIDDEN, "CM402", "해당 게시글에는 댓글이 존재하지 않습니다.");
   private final HttpStatus status;
   private final String code;
   private final String message;

--- a/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentController.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentController.java
@@ -54,8 +54,9 @@ public class CommentController {
 
   @DeleteMapping("/{post}/{comment_id}")
   public ResponseEntity<ApiResponseData<String>> deleteComment(@PathVariable("post") String postId,
-                                                               @PathVariable("comment_id") UUID commentId){
-    commentDomainService.deleteComment(postId, commentId);
+                                                               @PathVariable("comment_id") UUID commentId,
+                                                               @AuthenticationPrincipal CustomUserDetails customUserDetails){
+    commentDomainService.deleteComment(postId, commentId, customUserDetails);
     return ResponseEntity.ok().body(ApiResponseData.of(COMMENT_DELETE.getCode(),COMMENT_DELETE.getMessage(), null));
   }
 

--- a/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentInternalController.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentInternalController.java
@@ -1,0 +1,31 @@
+package com.sparta.moim.comment.presentation.controller;
+
+import static com.sparta.moim.comment.infrastructure.response.CommentCode.*;
+
+import com.sparta.moim.comment.domain.repository.CommentRepository;
+import com.sparta.moim.comment.domain.service.CommentDomainService;
+import com.sparta.moim.comment.infrastructure.response.CommentCode;
+import com.sparta.moim.common.response.ApiResponseData;
+import com.sparta.moim.common.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/comment")
+@RequiredArgsConstructor
+public class CommentInternalController {
+
+  private final CommentDomainService commentDomainService;
+  //실제로 존재하는 게시물의 postId를 보내주셔야 합니다.
+  @DeleteMapping("/{postId}")
+  public ResponseEntity<ApiResponseData<String>> deleteComments(@PathVariable("postId") String postId, @AuthenticationPrincipal CustomUserDetails customUserDetails){
+    commentDomainService.deleteComments(postId,customUserDetails);
+    return ResponseEntity.ok().body(ApiResponseData.of(COMMENT_DELETE.getCode(), COMMENT_DELETE.getMessage(),null ));
+  }
+}

--- a/post-service/src/main/java/com/moim/post/presentation/PostServiceController.java
+++ b/post-service/src/main/java/com/moim/post/presentation/PostServiceController.java
@@ -21,7 +21,7 @@ public class PostServiceController {
   private final PostPresentationMapper mapper;
 
   @GetMapping("/feeds/{id}")
-  public ValidationResponse isValidFeed(@PathVariable final String id) {
+  public ValidationResponse isValidFeed(@PathVariable("id") final String id) {
     log.info("[Internal] Feed 유효성 요청: {}", id);
     Boolean result = useCase.isValidFeed(mapper.toQuery(UUID.fromString(id)));
     ValidationResponse response = mapper.toResponse(result);

--- a/post-service/src/main/resources/application-external.yml
+++ b/post-service/src/main/resources/application-external.yml
@@ -1,7 +1,7 @@
 eureka:
   client:
     serviceUrl:
-      defaultZone: http://${EUREKA_HOST:localhost}:${EUREKA_PORT}/eureka/
+      defaultZone: http://localhost:${EUREKA_PORT}/eureka/
   instance:
     hostname: localhost    # 추가: 호스트명 명시적 설정
     preferIpAddress: true


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
- 댓글 삭제 api 추가
- 게시물 삭제시, 실행되는 feignclient 설정
- 댓글이 존재하지 않으면 예외처리 실행

### 2️⃣ 변경 이유


### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 게시글에 포함된 모든 댓글을 한 번에 삭제할 수 있는 내부 API 엔드포인트가 추가되었습니다.

- **버그 수정**
    - 댓글 삭제 시 인증된 사용자 정보가 올바르게 반영되도록 개선되었습니다.

- **기타**
    - 일부 API 경로 변수 명시 및 설정 파일의 Eureka 호스트명이 명확하게 지정되었습니다.
    - 댓글 관련 오류 코드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->