### PR TITLE
[Post] Role 검증 Validation 추가

### DIFF
--- a/post-service/build.gradle
+++ b/post-service/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     implementation 'com.google.guava:guava:33.1.0-jre'
 
+    // security
+    implementation "org.springframework.boot:spring-boot-starter-security"
+
 }
 
 ext {

--- a/post-service/src/main/java/com/moim/post/application/PostCommandService.java
+++ b/post-service/src/main/java/com/moim/post/application/PostCommandService.java
@@ -5,12 +5,17 @@ import com.moim.post.application.command.CreateVoteCommand;
 import com.moim.post.application.command.DeleteCommand;
 import com.moim.post.application.command.UpdateFeedCommand;
 import com.moim.post.application.command.UpdateVoteCommand;
+import com.moim.post.application.exception.NotFoundFeed;
+import com.moim.post.application.exception.NotFoundVote;
+import com.moim.post.application.exception.PostUnauthorizedAccessException;
 import com.moim.post.application.usecase.PostCommandUseCase;
+import com.moim.post.application.validation.RoleValidator;
 import com.moim.post.domain.feed.Feed;
 import com.moim.post.domain.repository.command.FeedCommandRepository;
 import com.moim.post.domain.repository.command.VoteCommandRepository;
 import com.moim.post.domain.repository.command.entitymanager.FeedEntityManager;
 import com.moim.post.domain.vote.Vote;
+import com.sparta.moim.common.security.CustomUserDetails;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -24,9 +29,14 @@ public class PostCommandService implements PostCommandUseCase {
   private final FeedCommandRepository feedRepository;
   private final VoteCommandRepository voteRepository;
   private final FeedEntityManager feedEntityManager;
+  private final RoleValidator roleValidator;
 
   @Override
-  public Feed createFeed(CreateFeedCommand command) {
+  public Feed createFeed(
+      CustomUserDetails userDetails,
+      CreateFeedCommand command
+  ) {
+    checkRole("CREATE", command.organizationId(), userDetails.getTrackingId());
     Feed feed = Feed.create(
         command.organizationId(),
         command.title(),
@@ -38,7 +48,11 @@ public class PostCommandService implements PostCommandUseCase {
   }
 
   @Override
-  public Vote createVote(CreateVoteCommand command) {
+  public Vote createVote(
+      CustomUserDetails userDetails,
+      CreateVoteCommand command
+  ) {
+    checkRole("CREATE", command.organizationId(), userDetails.getTrackingId());
     Vote vote = Vote.create(
         command.organizationId(),
         command.title(),
@@ -51,9 +65,13 @@ public class PostCommandService implements PostCommandUseCase {
   }
 
   @Override
-  public Feed updateFeed(UUID id, UpdateFeedCommand command) {
-    // todo : 예외처리
-    Feed feed = feedRepository.findByTrackingId(id).orElseThrow(null);
+  public Feed updateFeed(
+      CustomUserDetails userDetails,
+      UUID id,
+      UpdateFeedCommand command
+  ) {
+    checkRole("UPDATE", command.organizationId(), userDetails.getTrackingId());
+    Feed feed = feedRepository.findByTrackingId(id).orElseThrow(NotFoundFeed::new);
     command.title().ifPresent(feed::updateTitle);
     command.content().ifPresent(feed::updateContent);
     command.imageUrl().ifPresent(feed::updateImageUrl);
@@ -65,9 +83,13 @@ public class PostCommandService implements PostCommandUseCase {
   }
 
   @Override
-  public Vote updateVote(UUID id, UpdateVoteCommand command) {
-    // todo : 예외처리
-    Vote vote = voteRepository.findByTrackingId(id).orElseThrow(null);
+  public Vote updateVote(
+      CustomUserDetails userDetails,
+      UUID id,
+      UpdateVoteCommand command
+  ) {
+    checkRole("UPDATE", command.organizationId(), userDetails.getTrackingId());
+    Vote vote = voteRepository.findByTrackingId(id).orElseThrow(NotFoundVote::new);
     command.title().ifPresent(vote::updateTitle);
     command.content().ifPresent(vote::updateContent);
     command.start().ifPresent(vote::updateStart);
@@ -77,18 +99,36 @@ public class PostCommandService implements PostCommandUseCase {
   }
 
   @Override
-  public void deleteFeed(DeleteCommand command) {
-    // todo: 예외처리
-    Feed feed = feedRepository.findByTrackingId(command.id()).orElseThrow(null);
+  public void deleteFeed(
+      CustomUserDetails userDetails,
+      DeleteCommand command
+  ) {
+    checkRole("DELETE", command.organizationId(), userDetails.getTrackingId());
+    Feed feed = feedRepository.findByTrackingId(command.postId()).orElseThrow(NotFoundFeed::new);
     feed.delete();
     // todo: 댓글 도메인에 삭제 이벤트 발행
   }
 
   @Override
-  public void deleteVote(DeleteCommand command) {
-    // todo: 예외처리
-    Vote vote = voteRepository.findByTrackingId(command.id()).orElseThrow(null);
+  public void deleteVote(
+      CustomUserDetails userDetails,
+      DeleteCommand command
+  ) {
+    checkRole("DELETE", command.organizationId(), userDetails.getTrackingId());
+    Vote vote = voteRepository.findByTrackingId(command.postId()).orElseThrow(NotFoundFeed::new);
     vote.delete();
   }
+
+  private void checkRole(
+      String requestType,
+      UUID organizationTrackingId,
+      UUID userTrackingId
+  ) {
+    Boolean result = roleValidator.isValidRole(requestType, organizationTrackingId, userTrackingId);
+    if (!result) {
+      throw new PostUnauthorizedAccessException();
+    }
+  }
+
 }
 

--- a/post-service/src/main/java/com/moim/post/application/PostCommandService.java
+++ b/post-service/src/main/java/com/moim/post/application/PostCommandService.java
@@ -115,7 +115,7 @@ public class PostCommandService implements PostCommandUseCase {
       DeleteCommand command
   ) {
     checkRole("DELETE", command.organizationId(), userDetails.getTrackingId());
-    Vote vote = voteRepository.findByTrackingId(command.postId()).orElseThrow(NotFoundFeed::new);
+    Vote vote = voteRepository.findByTrackingId(command.postId()).orElseThrow(NotFoundVote::new);
     vote.delete();
   }
 

--- a/post-service/src/main/java/com/moim/post/application/PostQueryService.java
+++ b/post-service/src/main/java/com/moim/post/application/PostQueryService.java
@@ -1,13 +1,19 @@
 package com.moim.post.application;
 
+import com.moim.post.application.exception.NotFoundFeed;
+import com.moim.post.application.exception.NotFoundVote;
+import com.moim.post.application.exception.PostUnauthorizedAccessException;
 import com.moim.post.application.query.FindQuery;
 import com.moim.post.application.query.SearchFeedQuery;
 import com.moim.post.application.query.SearchVoteQuery;
 import com.moim.post.application.usecase.PostQueryUseCase;
+import com.moim.post.application.validation.RoleValidator;
 import com.moim.post.domain.feed.Feed;
 import com.moim.post.domain.repository.query.FeedQueryRepository;
 import com.moim.post.domain.repository.query.VoteQueryRepository;
 import com.moim.post.domain.vote.Vote;
+import com.sparta.moim.common.security.CustomUserDetails;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -24,20 +30,26 @@ public class PostQueryService implements PostQueryUseCase {
 
   private final FeedQueryRepository feedRepository;
   private final VoteQueryRepository voteRepository;
+  private final RoleValidator roleValidator;
 
   @Override
-  public Feed findFeed(FindQuery query) {
-    // todo: 예외처리하기
-    return feedRepository.findFeed(query.id()).orElseThrow(null);
+  public Feed findFeed(
+      CustomUserDetails userDetails,
+      FindQuery query
+  ) {
+    checkRole("READ", query.id(), userDetails.getTrackingId());
+    return feedRepository.findFeed(query.id()).orElseThrow(NotFoundFeed::new);
   }
 
   @Override
   public Page<Feed> searchFeed(
+      CustomUserDetails userDetails,
       SearchFeedQuery query,
       int page,
       int size,
       String sortType
   ) {
+    checkRole("READ", query.organizationId().get(), userDetails.getTrackingId());
     Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sortType));
     return feedRepository.searchFeed(
         query.organizationId(),
@@ -47,13 +59,23 @@ public class PostQueryService implements PostQueryUseCase {
   }
 
   @Override
-  public Vote findVote(FindQuery query) {
-    // todo: 예외처리하기
-    return voteRepository.findVote(query.id()).orElseThrow(null);
+  public Vote findVote(
+      CustomUserDetails userDetails,
+      FindQuery query
+  ) {
+    checkRole("READ", query.id(), userDetails.getTrackingId());
+    return voteRepository.findVote(query.id()).orElseThrow(NotFoundVote::new);
   }
 
   @Override
-  public Page<Vote> searchVote(SearchVoteQuery query, int page, int size, String sortType) {
+  public Page<Vote> searchVote(
+      CustomUserDetails userDetails,
+      SearchVoteQuery query,
+      int page,
+      int size,
+      String sortType
+  ) {
+    checkRole("READ", query.organizationId().get(), userDetails.getTrackingId());
     Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, sortType));
     return voteRepository.searchVote(
         query.organizationId(),
@@ -70,4 +92,16 @@ public class PostQueryService implements PostQueryUseCase {
         .filter(feed -> !feed.getIsDeleted())
         .isPresent();
   }
+
+  private void checkRole(
+      String requestType,
+      UUID organizationTrackingId,
+      UUID userTrackingId
+  ) {
+    Boolean result = roleValidator.isValidRole(requestType, organizationTrackingId, userTrackingId);
+    if (!result) {
+      throw new PostUnauthorizedAccessException();
+    }
+  }
+
 }

--- a/post-service/src/main/java/com/moim/post/application/command/DeleteCommand.java
+++ b/post-service/src/main/java/com/moim/post/application/command/DeleteCommand.java
@@ -3,6 +3,7 @@ package com.moim.post.application.command;
 import java.util.UUID;
 
 public record DeleteCommand(
-    UUID id
+    UUID organizationId,
+    UUID postId
 ) {
 }

--- a/post-service/src/main/java/com/moim/post/application/command/UpdateFeedCommand.java
+++ b/post-service/src/main/java/com/moim/post/application/command/UpdateFeedCommand.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public record UpdateFeedCommand(
+    UUID organizationId,
     Optional<String> title,
     Optional<String> content,
     Optional<String> imageUrl,

--- a/post-service/src/main/java/com/moim/post/application/command/UpdateVoteCommand.java
+++ b/post-service/src/main/java/com/moim/post/application/command/UpdateVoteCommand.java
@@ -2,8 +2,10 @@ package com.moim.post.application.command;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 public record UpdateVoteCommand(
+    UUID organizationId,
     Optional<String> title,
     Optional<String> content,
     Optional<LocalDateTime> start,

--- a/post-service/src/main/java/com/moim/post/application/exception/NotFoundFeed.java
+++ b/post-service/src/main/java/com/moim/post/application/exception/NotFoundFeed.java
@@ -1,0 +1,10 @@
+package com.moim.post.application.exception;
+
+import com.moim.post.application.exception.code.PostExceptionCode;
+import com.sparta.moim.common.exception.BaseException;
+
+public class NotFoundFeed extends BaseException {
+  public NotFoundFeed() {
+    super(PostExceptionCode.NOT_FOUND_FEED);
+  }
+}

--- a/post-service/src/main/java/com/moim/post/application/exception/NotFoundVote.java
+++ b/post-service/src/main/java/com/moim/post/application/exception/NotFoundVote.java
@@ -1,0 +1,10 @@
+package com.moim.post.application.exception;
+
+import com.moim.post.application.exception.code.PostExceptionCode;
+import com.sparta.moim.common.exception.BaseException;
+
+public class NotFoundVote extends BaseException {
+  public NotFoundVote() {
+    super(PostExceptionCode.NOT_FOUND_VOTE);
+  }
+}

--- a/post-service/src/main/java/com/moim/post/application/exception/PostUnauthorizedAccessException.java
+++ b/post-service/src/main/java/com/moim/post/application/exception/PostUnauthorizedAccessException.java
@@ -1,0 +1,10 @@
+package com.moim.post.application.exception;
+
+import com.moim.post.application.exception.code.PostExceptionCode;
+import com.sparta.moim.common.exception.BaseException;
+
+public class PostUnauthorizedAccessException extends BaseException {
+  public PostUnauthorizedAccessException() {
+    super(PostExceptionCode.UNAUTHORIZED_REQUEST);
+  }
+}

--- a/post-service/src/main/java/com/moim/post/application/exception/code/PostExceptionCode.java
+++ b/post-service/src/main/java/com/moim/post/application/exception/code/PostExceptionCode.java
@@ -1,0 +1,24 @@
+package com.moim.post.application.exception.code;
+
+import com.sparta.moim.common.response.Code;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum PostExceptionCode implements Code {
+
+  NOT_FOUND_FEED(HttpStatus.NOT_FOUND, "P001", "피드을 찾을 수 없습니다."),
+  NOT_FOUND_VOTE(HttpStatus.NOT_FOUND, "P002", "투표을 찾을 수 없습니다."),
+  UNAUTHORIZED_REQUEST(HttpStatus.UNAUTHORIZED, "P003", "해당 요청에 대한 권한이 없습니다.");
+
+  private final HttpStatus status;
+  private final String code;
+  private final String message;
+
+  PostExceptionCode(HttpStatus status, String code, String message) {
+    this.status = status;
+    this.code = code;
+    this.message = message;
+  }
+
+}

--- a/post-service/src/main/java/com/moim/post/application/usecase/PostCommandUseCase.java
+++ b/post-service/src/main/java/com/moim/post/application/usecase/PostCommandUseCase.java
@@ -7,13 +7,14 @@ import com.moim.post.application.command.UpdateFeedCommand;
 import com.moim.post.application.command.UpdateVoteCommand;
 import com.moim.post.domain.feed.Feed;
 import com.moim.post.domain.vote.Vote;
+import com.sparta.moim.common.security.CustomUserDetails;
 import java.util.UUID;
 
 public interface PostCommandUseCase {
-  Feed createFeed(CreateFeedCommand command);
-  Feed updateFeed(UUID id, UpdateFeedCommand command);
-  Vote createVote(CreateVoteCommand command);
-  Vote updateVote(UUID id, UpdateVoteCommand command);
-  void deleteFeed(DeleteCommand command);
-  void deleteVote(DeleteCommand command);
+  Feed createFeed(CustomUserDetails userDetails, CreateFeedCommand command);
+  Feed updateFeed(CustomUserDetails userDetails, UUID id, UpdateFeedCommand command);
+  Vote createVote(CustomUserDetails userDetails, CreateVoteCommand command);
+  Vote updateVote(CustomUserDetails userDetails, UUID id, UpdateVoteCommand command);
+  void deleteFeed(CustomUserDetails userDetails, DeleteCommand command);
+  void deleteVote(CustomUserDetails userDetails, DeleteCommand command);
 }

--- a/post-service/src/main/java/com/moim/post/application/usecase/PostQueryUseCase.java
+++ b/post-service/src/main/java/com/moim/post/application/usecase/PostQueryUseCase.java
@@ -5,21 +5,30 @@ import com.moim.post.application.query.SearchFeedQuery;
 import com.moim.post.application.query.SearchVoteQuery;
 import com.moim.post.domain.feed.Feed;
 import com.moim.post.domain.vote.Vote;
+import com.sparta.moim.common.security.CustomUserDetails;
 import org.springframework.data.domain.Page;
 
 public interface PostQueryUseCase {
-  Feed findFeed(FindQuery query);
+  Feed findFeed(
+      CustomUserDetails userDetails,
+      FindQuery query
+  );
 
   Page<Feed> searchFeed(
+      CustomUserDetails userDetails,
       SearchFeedQuery query,
       int page,
       int size,
       String sortType
   );
 
-  Vote findVote(FindQuery query);
+  Vote findVote(
+      CustomUserDetails userDetails,
+      FindQuery query
+  );
 
   Page<Vote> searchVote(
+      CustomUserDetails userDetails,
       SearchVoteQuery query,
       int page,
       int size,

--- a/post-service/src/main/java/com/moim/post/application/validation/RoleValidator.java
+++ b/post-service/src/main/java/com/moim/post/application/validation/RoleValidator.java
@@ -1,0 +1,37 @@
+package com.moim.post.application.validation;
+
+import com.moim.post.infrastructure.feign.organization.OrganizationClient;
+import com.moim.post.infrastructure.feign.organization.OrganizationMemberRole;
+import com.sparta.moim.common.response.ApiResponseData;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RoleValidator {
+
+  private static final Map<String, List<OrganizationMemberRole>> REQUEST_ROLE = Map.of(
+      "READ", List.of(OrganizationMemberRole.MEMBER, OrganizationMemberRole.MANAGER, OrganizationMemberRole.MASTER),
+      "CREATE", List.of(OrganizationMemberRole.MANAGER, OrganizationMemberRole.MASTER),
+      "UPDATE", List.of(OrganizationMemberRole.MANAGER, OrganizationMemberRole.MASTER),
+      "DELETE", List.of(OrganizationMemberRole.MANAGER, OrganizationMemberRole.MASTER)
+  );
+
+  private final OrganizationClient organizationClient;
+
+  public Boolean isValidRole(
+      String requestType,
+      UUID organizationTrackingId,
+      UUID userTrackingId
+  ) {
+    ApiResponseData<Boolean> result = organizationClient.checkRole(
+        organizationTrackingId.toString(),
+        userTrackingId.toString(),
+        REQUEST_ROLE.getOrDefault(requestType.toUpperCase(), List.of())
+    );
+    return result.getData();
+  }
+}

--- a/post-service/src/main/java/com/moim/post/infrastructure/feign/organization/OrganizationClient.java
+++ b/post-service/src/main/java/com/moim/post/infrastructure/feign/organization/OrganizationClient.java
@@ -1,0 +1,20 @@
+package com.moim.post.infrastructure.feign.organization;
+
+import com.sparta.moim.common.response.ApiResponseData;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "organization-service", url = "${feign.url.organization}")
+public interface OrganizationClient {
+  @GetMapping("/{organizationTrackingId}/members/{userTrackingId}/has-role")
+  ApiResponseData<Boolean> checkRole(
+      @PathVariable String organizationTrackingId,
+      @PathVariable String userTrackingId,
+      @RequestParam List<OrganizationMemberRole> roles
+  );
+
+
+}

--- a/post-service/src/main/java/com/moim/post/infrastructure/feign/organization/OrganizationMemberRole.java
+++ b/post-service/src/main/java/com/moim/post/infrastructure/feign/organization/OrganizationMemberRole.java
@@ -1,0 +1,7 @@
+package com.moim.post.infrastructure.feign.organization;
+
+public enum OrganizationMemberRole {
+  MEMBER,
+  MANAGER,
+  MASTER,
+}

--- a/post-service/src/main/java/com/moim/post/presentation/PostCommandController.java
+++ b/post-service/src/main/java/com/moim/post/presentation/PostCommandController.java
@@ -6,16 +6,19 @@ import com.moim.post.domain.vote.Vote;
 import com.moim.post.presentation.mapper.PostPresentationMapper;
 import com.moim.post.presentation.request.CreateFeedRequest;
 import com.moim.post.presentation.request.CreateVoteRequest;
+import com.moim.post.presentation.request.DeleteRequest;
 import com.moim.post.presentation.request.UpdateFeedRequest;
 import com.moim.post.presentation.request.UpdateVoteRequest;
 import com.moim.post.presentation.response.FeedResponse;
 import com.moim.post.presentation.response.VoteResponse;
 import com.sparta.moim.common.response.ApiResponseData;
+import com.sparta.moim.common.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,10 +37,11 @@ public class PostCommandController {
 
   @PostMapping("/feeds")
   public ResponseEntity<ApiResponseData<FeedResponse>> createFeed(
-      @Valid @RequestBody CreateFeedRequest request
+      @Valid @RequestBody CreateFeedRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     log.info("Feed 생성 요청: {}", request.toString());
-    Feed feed = useCase.createFeed(mapper.toCommand(request));
+    Feed feed = useCase.createFeed(userDetails, mapper.toCommand(request));
     FeedResponse response = mapper.toResponse(feed);
     log.info("Feed 생성 및 저장 완료: {}", response.id().toString());
     return ResponseEntity.ok().body(ApiResponseData.success(response));
@@ -45,10 +49,11 @@ public class PostCommandController {
 
   @PostMapping("/votes")
   public ResponseEntity<ApiResponseData<VoteResponse>> createVotes(
-      @Valid @RequestBody CreateVoteRequest request
+      @Valid @RequestBody CreateVoteRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     log.info("Vote 생성 요청: {}", request.toString());
-    Vote vote = useCase.createVote(mapper.toCommand(request));
+    Vote vote = useCase.createVote(userDetails, mapper.toCommand(request));
     VoteResponse response = mapper.toResponse(vote);
     log.info("Vote 생성 및 저장 완료: {}", response.id().toString());
     return ResponseEntity.ok().body(ApiResponseData.success(response));
@@ -57,11 +62,12 @@ public class PostCommandController {
   @PostMapping("/feeds/{id}")
   public ResponseEntity<ApiResponseData<FeedResponse>> updateFeed(
       @PathVariable final String id,
-      @RequestBody UpdateFeedRequest request
+      @RequestBody UpdateFeedRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     log.info("Feed 업데이트 요청: {}", id);
     log.info("Feed 업데이트 내역: {}", request.toString());
-    Feed feed = useCase.updateFeed(UUID.fromString(id), mapper.toCommand(request));
+    Feed feed = useCase.updateFeed(userDetails, UUID.fromString(id), mapper.toCommand(request));
     FeedResponse response = mapper.toResponse(feed);
     log.info("Feed 업데이트 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(response));
@@ -70,28 +76,35 @@ public class PostCommandController {
   @PostMapping("/votes/{id}")
   public ResponseEntity<ApiResponseData<VoteResponse>> updateVote(
       @PathVariable final String id,
-      @RequestBody UpdateVoteRequest request
+      @RequestBody UpdateVoteRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     log.info("Vote 업데이트 요청: {}", id);
     log.info("Vote 업데이트 내역: {}", request.toString());
-    Vote vote = useCase.updateVote(UUID.fromString(id), mapper.toCommand(request));
+    Vote vote = useCase.updateVote(userDetails, UUID.fromString(id), mapper.toCommand(request));
     VoteResponse response = mapper.toResponse(vote);
     log.info("Vote 업데이트 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(response));
   }
 
-  @DeleteMapping("/feeds/{id}")
-  public ResponseEntity<ApiResponseData> deleteFeed(@PathVariable final String id) {
-    log.info("Feed 삭제 요청: {}", id);
-    useCase.deleteFeed(mapper.toCommand(UUID.fromString(id)));
+  @DeleteMapping("/feeds")
+  public ResponseEntity<ApiResponseData> deleteFeed(
+      @Valid @RequestBody DeleteRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    log.info("Feed 삭제 요청: {}", request.postId());
+    useCase.deleteFeed(userDetails, mapper.toCommand(request));
     log.info("Feed 삭제 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(null));
   }
 
-  @DeleteMapping("/votes/{id}")
-  public ResponseEntity<ApiResponseData> deleteVote(@PathVariable final String id) {
-    log.info("Vote 삭제 요청: {}", id);
-    useCase.deleteVote(mapper.toCommand(UUID.fromString(id)));
+  @DeleteMapping("/votes")
+  public ResponseEntity<ApiResponseData> deleteVote(
+      @Valid @RequestBody DeleteRequest request,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    log.info("Vote 삭제 요청: {}", request.postId());
+    useCase.deleteVote(userDetails, mapper.toCommand(request));
     log.info("Vote 삭제 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(null));
   }

--- a/post-service/src/main/java/com/moim/post/presentation/PostQueryController.java
+++ b/post-service/src/main/java/com/moim/post/presentation/PostQueryController.java
@@ -9,11 +9,13 @@ import com.moim.post.presentation.request.SearchVoteRequest;
 import com.moim.post.presentation.response.FeedResponse;
 import com.moim.post.presentation.response.VoteResponse;
 import com.sparta.moim.common.response.ApiResponseData;
+import com.sparta.moim.common.security.CustomUserDetails;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,9 +33,12 @@ public class PostQueryController {
   private final PostPresentationMapper mapper;
 
   @GetMapping("/feeds/{id}")
-  public ResponseEntity<ApiResponseData<FeedResponse>> findFeed(@PathVariable final String id) {
+  public ResponseEntity<ApiResponseData<FeedResponse>> findFeed(
+      @PathVariable final String id,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
     log.info("Feed 조회 요청: {}", id);
-    Feed feed = useCase.findFeed(mapper.toQuery(UUID.fromString(id)));
+    Feed feed = useCase.findFeed(userDetails, mapper.toQuery(UUID.fromString(id)));
     FeedResponse response = mapper.toResponse(feed);
     log.info("Feed 조회 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(response));
@@ -44,17 +49,21 @@ public class PostQueryController {
       @ModelAttribute final SearchFeedRequest request,
       @RequestParam(defaultValue = "0") final int page,
       @RequestParam(defaultValue = "10") final int size,
-      @RequestParam(defaultValue = "createdAt") final String sortType
+      @RequestParam(defaultValue = "createdAt") final String sortType,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    Page<FeedResponse> response = useCase.searchFeed(mapper.toQuery(request), page, size, sortType)
+    Page<FeedResponse> response = useCase.searchFeed(userDetails, mapper.toQuery(request), page, size, sortType)
         .map(mapper::toResponse);
     return ResponseEntity.ok().body(ApiResponseData.success(response));
   }
 
   @GetMapping("/votes/{id}")
-  public ResponseEntity<ApiResponseData<VoteResponse>> findVote(@PathVariable final String id) {
+  public ResponseEntity<ApiResponseData<VoteResponse>> findVote(
+      @PathVariable final String id,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
     log.info("Vote 조회 요청: {}", id);
-    Vote vote = useCase.findVote(mapper.toQuery(UUID.fromString(id)));
+    Vote vote = useCase.findVote(userDetails, mapper.toQuery(UUID.fromString(id)));
     VoteResponse response = mapper.toResponse(vote);
     log.info("Vote 조회 완료");
     return ResponseEntity.ok().body(ApiResponseData.success(response));
@@ -65,9 +74,10 @@ public class PostQueryController {
       @ModelAttribute final SearchVoteRequest request,
       @RequestParam(defaultValue = "0") final int page,
       @RequestParam(defaultValue = "10") final int size,
-      @RequestParam(defaultValue = "createdAt") final String sortType
+      @RequestParam(defaultValue = "createdAt") final String sortType,
+      @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    Page<VoteResponse> response = useCase.searchVote(mapper.toQuery(request), page, size, sortType)
+    Page<VoteResponse> response = useCase.searchVote(userDetails, mapper.toQuery(request), page, size, sortType)
         .map(mapper::toResponse);
     return ResponseEntity.ok().body(ApiResponseData.success(response));
   }

--- a/post-service/src/main/java/com/moim/post/presentation/mapper/PostPresentationMapper.java
+++ b/post-service/src/main/java/com/moim/post/presentation/mapper/PostPresentationMapper.java
@@ -12,6 +12,7 @@ import com.moim.post.domain.feed.Feed;
 import com.moim.post.domain.vote.Vote;
 import com.moim.post.presentation.request.CreateFeedRequest;
 import com.moim.post.presentation.request.CreateVoteRequest;
+import com.moim.post.presentation.request.DeleteRequest;
 import com.moim.post.presentation.request.SearchFeedRequest;
 import com.moim.post.presentation.request.SearchVoteRequest;
 import com.moim.post.presentation.request.UpdateFeedRequest;
@@ -47,7 +48,7 @@ public interface PostPresentationMapper {
 
   UpdateVoteCommand toCommand(UpdateVoteRequest request);
 
-  DeleteCommand toCommand(UUID id);
+  DeleteCommand toCommand(DeleteRequest request);
 
   ValidationResponse toResponse(Boolean result);
 }

--- a/post-service/src/main/java/com/moim/post/presentation/request/DeleteRequest.java
+++ b/post-service/src/main/java/com/moim/post/presentation/request/DeleteRequest.java
@@ -1,0 +1,11 @@
+package com.moim.post.presentation.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record DeleteRequest(
+    @NotNull UUID organizationId,
+    @NotNull UUID postId
+){
+}
+

--- a/post-service/src/main/java/com/moim/post/presentation/request/UpdateFeedRequest.java
+++ b/post-service/src/main/java/com/moim/post/presentation/request/UpdateFeedRequest.java
@@ -1,22 +1,26 @@
 package com.moim.post.presentation.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public record UpdateFeedRequest(
+    @NotNull UUID organizationId,
     Optional<String> title,
     Optional<String> content,
     Optional<String> imageUrl,
     Optional<List<UUID>> taggedUserIds
 ){
   public UpdateFeedRequest(
+      UUID organizationId,
       String title,
       String content,
       String imageUrl,
       List<UUID> taggedUserIds
   ){
     this(
+        organizationId,
         Optional.ofNullable(title),
         Optional.ofNullable(content),
         Optional.ofNullable(imageUrl),

--- a/post-service/src/main/java/com/moim/post/presentation/request/UpdateVoteRequest.java
+++ b/post-service/src/main/java/com/moim/post/presentation/request/UpdateVoteRequest.java
@@ -1,9 +1,12 @@
 package com.moim.post.presentation.request;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 
 public record UpdateVoteRequest(
+    @NotNull UUID organizationId,
     Optional<String> title,
     Optional<String> content,
     Optional<LocalDateTime> start,
@@ -11,6 +14,7 @@ public record UpdateVoteRequest(
     Optional<Integer> totalVoter
 ){
   public UpdateVoteRequest(
+      UUID organizationId,
       String title,
       String content,
       LocalDateTime start,
@@ -18,6 +22,7 @@ public record UpdateVoteRequest(
       Integer totalVoter
   ){
     this(
+        organizationId,
         Optional.ofNullable(title),
         Optional.ofNullable(content),
         Optional.ofNullable(start),

--- a/post-service/src/main/resources/application-external.yml
+++ b/post-service/src/main/resources/application-external.yml
@@ -20,3 +20,7 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+feign:
+  url:
+    organization: ${ORGANIZATION_CLIENT_URL}


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항


### 2️⃣ 변경 이유


### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 인증된 사용자만 피드 및 투표의 생성, 조회, 수정, 삭제가 가능하도록 역할 기반 권한 검증이 적용되었습니다.
  - 피드와 투표 삭제 요청 시 조직 ID와 게시물 ID를 함께 전달하는 구조로 변경되었습니다.
  - 권한 부족, 피드/투표 미존재 시 도메인별 예외 메시지가 제공됩니다.
  - 조직 서비스와 연동하여 사용자 역할을 검증하는 기능이 추가되었습니다.

- **버그 수정**
  - 피드 및 투표 조회/수정/삭제 시 잘못된 예외 처리 대신 구체적인 예외가 반환됩니다.

- **API 변경**
  - 모든 피드/투표 관련 API에 사용자 인증 정보가 필수로 포함됩니다.
  - 피드 및 투표 삭제 API가 PathVariable 방식에서 Request Body 방식으로 변경되었습니다.
  - 피드 및 투표 수정 요청에 조직 ID 필드가 추가되었습니다.

- **설정**
  - 외부 조직 서비스와의 연동을 위한 Feign 클라이언트 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->