### PR TITLE
[Gathering] 패키지 구조가 1개로 변경되어 shared패키지 제거

### DIFF
--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/code/GatheringCode.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/code/GatheringCode.java
@@ -1,4 +1,4 @@
-package com.sparta.moim.gathering.shared.error.code;
+package com.sparta.moim.gathering.gathering.application.dto.code;
 
 import com.sparta.moim.common.response.Code;
 import lombok.Getter;

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAdminRevokeEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAdminRevokeEvent.java
@@ -1,0 +1,8 @@
+package com.sparta.moim.gathering.gathering.application.dto.event;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record GatheringAdminRevokeEvent(UUID gatheringId, String ownerName) {
+}

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAdminSaveEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAdminSaveEvent.java
@@ -1,0 +1,8 @@
+package com.sparta.moim.gathering.gathering.application.dto.event;
+
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record GatheringAdminSaveEvent(UUID gatheringId, String memberName, String type) {
+}

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/exception/GatheringException.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/exception/GatheringException.java
@@ -1,6 +1,6 @@
-package com.sparta.moim.gathering.shared.error.exception;
+package com.sparta.moim.gathering.gathering.application.exception;
 
-import com.sparta.moim.gathering.shared.error.code.GatheringCode;
+import com.sparta.moim.gathering.gathering.application.dto.code.GatheringCode;
 import com.sparta.moim.common.exception.BaseException;
 
 public class GatheringException extends BaseException {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/GatheringService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/GatheringService.java
@@ -14,8 +14,8 @@ import com.sparta.moim.gathering.gathering.application.event.publisher.MemberPub
 import com.sparta.moim.gathering.gathering.domain.entity.Gathering;
 import com.sparta.moim.gathering.gathering.domain.repository.GatheringRepository;
 import com.sparta.moim.gathering.gathering.domain.repository.GatheringRepositoryCustom;
-import com.sparta.moim.gathering.shared.error.code.GatheringCode;
-import com.sparta.moim.gathering.shared.error.exception.GatheringException;
+import com.sparta.moim.gathering.gathering.application.dto.code.GatheringCode;
+import com.sparta.moim.gathering.gathering.application.exception.GatheringException;
 import com.sparta.moim.common.page.Pagination;
 import java.util.List;
 import java.util.UUID;

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/GatheringValidationService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/GatheringValidationService.java
@@ -1,8 +1,8 @@
 package com.sparta.moim.gathering.gathering.application.service;
 
 import com.sparta.moim.gathering.gathering.domain.repository.GatheringValidationRepository;
-import com.sparta.moim.gathering.shared.error.code.GatheringCode;
-import com.sparta.moim.gathering.shared.error.exception.GatheringException;
+import com.sparta.moim.gathering.gathering.application.dto.code.GatheringCode;
+import com.sparta.moim.gathering.gathering.application.exception.GatheringException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/MemberService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/MemberService.java
@@ -6,8 +6,8 @@ import com.sparta.moim.gathering.gathering.application.dto.command.SearchGatheri
 import com.sparta.moim.gathering.gathering.application.event.feign.InternalGatheringService;
 import com.sparta.moim.gathering.gathering.domain.enums.MemberType;
 import com.sparta.moim.gathering.gathering.domain.enums.MemberRepository;
-import com.sparta.moim.gathering.shared.error.code.GatheringCode;
-import com.sparta.moim.gathering.shared.error.exception.GatheringException;
+import com.sparta.moim.gathering.gathering.application.dto.code.GatheringCode;
+import com.sparta.moim.gathering.gathering.application.exception.GatheringException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
@@ -1,7 +1,7 @@
 package com.sparta.moim.gathering.gathering.domain.entity;
 
 import com.sparta.moim.gathering.gathering.domain.enums.MemberType;
-import com.sparta.moim.gathering.shared.dto.SharedGatheringMember;
+import com.sparta.moim.gathering.gathering.application.dto.event.GatheringAdminSaveEvent;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -41,11 +41,11 @@ public class Member {
 
   private LocalDateTime joinTime;
 
-  public static Member from(SharedGatheringMember sharedGatheringMember) {
+  public static Member from(GatheringAdminSaveEvent gatheringAdminSaveEvent) {
     return Member.builder()
-        .gatheringId(sharedGatheringMember.gatheringId())
-        .memberId(sharedGatheringMember.memberName())
-        .type(MemberType.valueOf(sharedGatheringMember.type()))
+        .gatheringId(gatheringAdminSaveEvent.gatheringId())
+        .memberId(gatheringAdminSaveEvent.memberName())
+        .type(MemberType.valueOf(gatheringAdminSaveEvent.type()))
         .joinTime(LocalDateTime.now())
         .build();
   }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/feign/listener/AddGatheringMemberListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/feign/listener/AddGatheringMemberListener.java
@@ -2,7 +2,7 @@ package com.sparta.moim.gathering.gathering.infrastructure.event.feign.listener;
 
 import com.sparta.moim.gathering.gathering.domain.entity.Member;
 import com.sparta.moim.gathering.gathering.domain.enums.MemberRepository;
-import com.sparta.moim.gathering.shared.dto.SharedGatheringMember;
+import com.sparta.moim.gathering.gathering.application.dto.event.GatheringAdminSaveEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -17,16 +17,16 @@ public class AddGatheringMemberListener {
   private final MemberRepository memberRepository;
   @EventListener
   @Transactional
-  public void save(SharedGatheringMember sharedGatheringMember) {
+  public void save(GatheringAdminSaveEvent gatheringAdminSaveEvent) {
     try {
-      log.info("소모임 멤버 저장 시작: {}", sharedGatheringMember.memberName());
-      memberRepository.save(Member.from(sharedGatheringMember));
-      log.info("소모임 멤버 저장 완료: {}", sharedGatheringMember.memberName());
+      log.info("소모임 멤버 저장 시작: {}", gatheringAdminSaveEvent.memberName());
+      memberRepository.save(Member.from(gatheringAdminSaveEvent));
+      log.info("소모임 멤버 저장 완료: {}", gatheringAdminSaveEvent.memberName());
     } catch (DataIntegrityViolationException e) {
-      log.warn("멤버 저장 중복 오류: {}: {}", sharedGatheringMember.memberName(), e.getMessage());
+      log.warn("멤버 저장 중복 오류: {}: {}", gatheringAdminSaveEvent.memberName(), e.getMessage());
         // 중복 데이터인 경우 별도 처리 로직
     }  catch (RuntimeException e) {
-      log.error("소모임 멤버 저장 실패: {}: {}", sharedGatheringMember.memberName(), e.getMessage(), e);
+      log.error("소모임 멤버 저장 실패: {}: {}", gatheringAdminSaveEvent.memberName(), e.getMessage(), e);
       //TODO 보상 트랜잭션 적용
     }
   }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/feign/listener/RevokeGatheringMemberListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/feign/listener/RevokeGatheringMemberListener.java
@@ -2,9 +2,9 @@ package com.sparta.moim.gathering.gathering.infrastructure.event.feign.listener;
 
 import com.sparta.moim.gathering.gathering.domain.entity.Member;
 import com.sparta.moim.gathering.gathering.domain.enums.MemberRepository;
-import com.sparta.moim.gathering.shared.dto.SharedGatheringRevokeMember;
-import com.sparta.moim.gathering.shared.error.code.GatheringCode;
-import com.sparta.moim.gathering.shared.error.exception.GatheringException;
+import com.sparta.moim.gathering.gathering.application.dto.event.GatheringAdminRevokeEvent;
+import com.sparta.moim.gathering.gathering.application.dto.code.GatheringCode;
+import com.sparta.moim.gathering.gathering.application.exception.GatheringException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -19,7 +19,7 @@ public class RevokeGatheringMemberListener {
 
   @EventListener
   @Transactional
-  public void revoke(SharedGatheringRevokeMember revokeMember) {
+  public void revoke(GatheringAdminRevokeEvent revokeMember) {
     try {
       log.info("소모임 관리자 저장 시작: {}", revokeMember.ownerName());
 

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherImpl.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherImpl.java
@@ -1,8 +1,8 @@
 package com.sparta.moim.gathering.gathering.infrastructure.event.publisher;
 
 import com.sparta.moim.gathering.gathering.application.event.publisher.MemberPublisher;
-import com.sparta.moim.gathering.shared.dto.SharedGatheringMember;
-import com.sparta.moim.gathering.shared.dto.SharedGatheringRevokeMember;
+import com.sparta.moim.gathering.gathering.application.dto.event.GatheringAdminSaveEvent;
+import com.sparta.moim.gathering.gathering.application.dto.event.GatheringAdminRevokeEvent;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -15,7 +15,7 @@ public class MemberPublisherImpl implements MemberPublisher {
 
   @Override
   public void add(UUID gatheringId, String memberName) {
-    publisher.publishEvent(SharedGatheringMember.builder()
+    publisher.publishEvent(GatheringAdminSaveEvent.builder()
         .gatheringId(gatheringId)
         .memberName(memberName)
         .type("ADMIN")
@@ -24,7 +24,7 @@ public class MemberPublisherImpl implements MemberPublisher {
 
   @Override
   public void revoke(UUID gatheringId, String owner) {
-    publisher.publishEvent(SharedGatheringRevokeMember.builder()
+    publisher.publishEvent(GatheringAdminRevokeEvent.builder()
         .gatheringId(gatheringId)
         .ownerName(owner)
         .build());

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/shared/dto/SharedGatheringMember.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/shared/dto/SharedGatheringMember.java
@@ -1,8 +1,0 @@
-package com.sparta.moim.gathering.shared.dto;
-
-import java.util.UUID;
-import lombok.Builder;
-
-@Builder
-public record SharedGatheringMember(UUID gatheringId, String memberName, String type) {
-}

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/shared/dto/SharedGatheringRevokeMember.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/shared/dto/SharedGatheringRevokeMember.java
@@ -1,8 +1,0 @@
-package com.sparta.moim.gathering.shared.dto;
-
-import java.util.UUID;
-import lombok.Builder;
-
-@Builder
-public record SharedGatheringRevokeMember(UUID gatheringId, String ownerName) {
-}


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
shared패키지 제거

### 2️⃣ 변경 이유
gathering,member로 관리되는것이 아닌 gatherng으로 관리 되어지므로 shared는 필요없다고 판단

### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 새로운 이벤트 타입인 GatheringAdminSaveEvent 및 GatheringAdminRevokeEvent가 추가되었습니다.

- **리팩터링**
    - 기존 SharedGatheringMember 및 SharedGatheringRevokeMember DTO가 삭제되고, 관련 로직이 새로운 이벤트 타입으로 대체되었습니다.
    - 여러 클래스에서 이벤트 및 예외 관련 패키지 구조가 변경되었습니다.
    - 일부 메서드의 파라미터 타입이 새로운 이벤트 타입으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->