### PR TITLE
[refactor] : 댓글 삭제(feignclient) 쿼리 튜닝

### DIFF
--- a/comment-service/src/main/java/com/sparta/moim/comment/domain/repository/CommentRepository.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/domain/repository/CommentRepository.java
@@ -4,6 +4,7 @@ import com.sparta.moim.comment.domain.model.Comment;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.repository.query.Param;
 
 public interface CommentRepository {
   Optional<Comment> save(Comment comment);
@@ -13,5 +14,7 @@ public interface CommentRepository {
   Optional<Comment> findComment(String postId, UUID commentId);
 
   List<Comment> searchComment(String postId, String comment);
+
+  void softDeleteByPostId(@Param("postId") String postId, @Param("userId") String userId);
 }
 

--- a/comment-service/src/main/java/com/sparta/moim/comment/domain/service/CommentDomainService.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/domain/service/CommentDomainService.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -77,14 +78,22 @@ public class CommentDomainService {
   }
 
   //특정 게시글의 전체 댓글 삭제
-  public void deleteComments(String postId, CustomUserDetails customUserDetails){
+  @Transactional
+  public boolean deleteComments(String postId, String userId){
     List<Comment> comments = commentRepository.findCommentAll(postId);
+
+    //댓글이 없을 경우, 삭제할 댓글이 없는 경우 이므로, true 반환
     if(comments.isEmpty()){
-      throw new BaseException(NO_COMMENT_IN_POST);
+      return true;
     }
-    for(Comment comment : comments) {
-      comment.softDelete(customUserDetails.getTrackingId().toString());
-      commentRepository.save(comment);
+
+    //댓글 삭제가 성공할 경우, true 반환. 실패하면, false 반환
+    try{
+      commentRepository.softDeleteByPostId(postId, userId);
+      return true;
+    }catch(Exception e){
+      log.error("댓글 삭제를 실패했습니다. postId: {}, userId: {}", postId, userId, e);
+      return false;
     }
 
   }

--- a/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/repository/CommentRepositoryImpl.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/repository/CommentRepositoryImpl.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -44,6 +45,11 @@ public class CommentRepositoryImpl implements CommentRepository {
         .where(qComment.postId.eq(postId)
             .and(qComment.comment.containsIgnoreCase(comment)))
         .fetch();
+  }
+
+  @Override
+  public void softDeleteByPostId(@Param("postId") String postId, @Param("userId") String userId){
+    jpaCommentRepository.softDeleteByPostId(postId,userId);
   }
 
 }

--- a/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/repository/JpaCommentRepository.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/infrastructure/repository/JpaCommentRepository.java
@@ -6,9 +6,16 @@ import java.util.Optional;
 import java.util.UUID;
 import org.hibernate.type.descriptor.converter.spi.JpaAttributeConverter;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaCommentRepository extends JpaRepository<Comment, Long> {
   List<Comment> findByPostIdAndDeletedByIsNullOrderByCreatedAtAsc(String postId);
 
   Optional<Comment> findByPostIdAndTrackingIdAndDeletedByIsNull(String postId, UUID trackingId);
+
+  @Modifying
+  @Query("UPDATE Comment c set c.deletedBy = :userId, c.deletedAt = CURRENT_TIMESTAMP WHERE c.postId = :postId")
+  void softDeleteByPostId(@Param("postId") String postId, @Param("userId") String userId);
 }

--- a/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentInternalController.java
+++ b/comment-service/src/main/java/com/sparta/moim/comment/presentation/controller/CommentInternalController.java
@@ -23,9 +23,12 @@ public class CommentInternalController {
 
   private final CommentDomainService commentDomainService;
   //실제로 존재하는 게시물의 postId를 보내주셔야 합니다.
-  @DeleteMapping("/{postId}")
-  public ResponseEntity<ApiResponseData<String>> deleteComments(@PathVariable("postId") String postId, @AuthenticationPrincipal CustomUserDetails customUserDetails){
-    commentDomainService.deleteComments(postId,customUserDetails);
-    return ResponseEntity.ok().body(ApiResponseData.of(COMMENT_DELETE.getCode(), COMMENT_DELETE.getMessage(),null ));
+  //해당 유저의 trackingId를 보내주셔야 합니다.
+  //서비스간의 내부 통신이기 때문에 유저 trackingId가 노출되어도 상관없습니다.
+  //댓글 삭제 완료 or 삭제할 댓글이 없는 경우 -> return true
+  //삭제 시, 에러가 발생하여 삭제가 안됨 -> return false
+  @DeleteMapping("/{postId}/{userId}")
+  public boolean deleteComments(@PathVariable("postId") String postId, @PathVariable("userId") String userId){
+    return commentDomainService.deleteComments(postId,userId);
   }
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
- 기존 댓글을 하나 씩 삭제(soft-delete)하는 로직을 수정
- 쿼리가 하나씩 날라가서 비효율적
- 벌크 업데이트를 통해서 한번의 쿼리를 통해 댓글 soft-delete 처리

### 2️⃣ 변경 이유


### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 게시글 ID와 사용자 ID를 기반으로 댓글을 일괄적으로 소프트 삭제하는 기능이 추가되었습니다.

- **버그 수정**
	- 댓글 삭제 시, 댓글이 없는 경우 예외 대신 true를 반환하도록 변경되었습니다.

- **리팩터링**
	- 내부 댓글 삭제 API가 인증 정보 대신 사용자 ID를 직접 받아 처리하도록 변경되었습니다.
	- 댓글 삭제 결과를 단순 boolean 값으로 반환하도록 응답 방식이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->