### PR TITLE
[ Organization ] OrganizationTrackingId로 해당 모임 존재여부 확인

### DIFF
--- a/organization-service/src/main/java/com/sparta/moim/organization/application/service/CheckOrganizationExistService.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/application/service/CheckOrganizationExistService.java
@@ -1,0 +1,18 @@
+package com.sparta.moim.organization.application.service;
+
+import com.sparta.moim.organization.application.usecase.CheckOrganizationExistsUseCase;
+import com.sparta.moim.organization.domain.repository.OrganizationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CheckOrganizationExistService implements CheckOrganizationExistsUseCase {
+
+    private final OrganizationRepository organizationRepository;
+
+    @Override
+    public boolean execute(String organizationTrackingId) {
+        return organizationRepository.existsByTrackingId(organizationTrackingId);
+    }
+}

--- a/organization-service/src/main/java/com/sparta/moim/organization/application/usecase/CheckOrganizationExistsUseCase.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/application/usecase/CheckOrganizationExistsUseCase.java
@@ -1,0 +1,5 @@
+package com.sparta.moim.organization.application.usecase;
+
+public interface CheckOrganizationExistsUseCase {
+    boolean execute(String organizationTrackingId);
+}

--- a/organization-service/src/main/java/com/sparta/moim/organization/domain/repository/OrganizationRepository.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/domain/repository/OrganizationRepository.java
@@ -3,11 +3,10 @@ package com.sparta.moim.organization.domain.repository;
 import com.sparta.moim.common.page.Pagination;
 import com.sparta.moim.organization.domain.entity.Organization;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface OrganizationRepository {
     Organization save(Organization organization);
     Optional<Organization> findByTrackingId(String organizationTrackingId);
     Pagination<Organization> findAll(int page, int size);
-
+    boolean existsByTrackingId(String organizationTrackingId);
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationJpaRepository.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationJpaRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrganizationJpaRepository extends JpaRepository<Organization, Long> {
     Optional<Organization> findByTrackingId(UUID trackingId);
+
+    boolean existsByTrackingId(UUID trackingId);
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationRepositoryImpl.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationRepositoryImpl.java
@@ -38,4 +38,9 @@ public class OrganizationRepositoryImpl implements OrganizationRepository {
                 organizationPage.getTotalElements(),
                 organizationPage.getContent());
     }
+
+    @Override
+    public boolean existsByTrackingId(String organizationTrackingId) {
+        return jpaRepository.existsByTrackingId(UUID.fromString(organizationTrackingId));
+    }
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/presentation/controller/in/OrganizationInternalController.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/presentation/controller/in/OrganizationInternalController.java
@@ -1,0 +1,23 @@
+package com.sparta.moim.organization.presentation.controller.in;
+
+import com.sparta.moim.common.response.ApiResponseData;
+import com.sparta.moim.organization.application.usecase.CheckOrganizationExistsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/organizations")
+@RequiredArgsConstructor
+public class OrganizationInternalController {
+
+    private final CheckOrganizationExistsUseCase checkOrganizationExistsUseCase;
+
+    @RequestMapping("/{organizationId}/exists")
+    public ApiResponseData<Boolean> checkOrganizationExists( @PathVariable("organizationId") String organizationId
+    ) {
+        return ApiResponseData.success(checkOrganizationExistsUseCase.execute(organizationId));
+    }
+
+}


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
- Feign을 통해 다른 서비스에서 OrganizationTrackingId를 통해 모임 존재여부를 확인할 수 있는 api를 만들었습니다.

### 2️⃣ 변경 이유
- 채팅 서비스쪽에서 필요하다하여 만들었습니다.

### 3️⃣ 추가 설명
true : 존재
false : 존재하지 않음.
true 혹은 false를 리턴합니다. soft delete된 모임도 false를 return합니다.

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 조직의 존재 여부를 확인할 수 있는 내부 API 엔드포인트가 추가되었습니다. (GET /internal/v1/organizations/{organizationId}/exists)
    - 조직 ID로 조직의 존재 여부를 조회하는 기능이 지원됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->