### PR TITLE
[ Organization ] Mock 데이터 넣는 로직 추가

### DIFF
--- a/organization-service/build.gradle
+++ b/organization-service/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+    //Fake Data
+    implementation ('com.github.javafaker:javafaker:1.0.2') { exclude module: 'snakeyaml' }
+    implementation group: 'org.yaml', name: 'snakeyaml', version: '2.2'
 }
 
 

--- a/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/Organization.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/Organization.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.Where;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Builder(access = AccessLevel.PRIVATE)
+@Builder // todo - private로 변경. 목데이터 넣어줄때 편하게 하려고 일단 지움.
 @Table(name = "p_organization")
 public class Organization extends BaseEntity {
 

--- a/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/OrganizationMember.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/OrganizationMember.java
@@ -28,7 +28,7 @@ import org.hibernate.annotations.Where;
 @Where(clause = "deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @Builder
 @Table(name = "p_organization_member")
 public class OrganizationMember extends BaseEntity {

--- a/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/OrganizationMember.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/domain/entity/OrganizationMember.java
@@ -42,10 +42,10 @@ public class OrganizationMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @UuidGenerator
-//    @JdbcTypeCode(Types.VARCHAR)
-//    @Column(name = "tracking_id", length = 36, nullable = false, unique = true)
-//    private UUID trackingId;
+    @UuidGenerator
+    @JdbcTypeCode(Types.VARCHAR)
+    @Column(name = "tracking_id", length = 36, nullable = false, unique = true)
+    private UUID trackingId;
 
     @JdbcTypeCode(Types.VARCHAR)
     @Column(name="user_tracking_id",length = 36, nullable = false)

--- a/organization-service/src/main/java/com/sparta/moim/organization/domain/repository/OrganizationRepository.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/domain/repository/OrganizationRepository.java
@@ -2,6 +2,7 @@ package com.sparta.moim.organization.domain.repository;
 
 import com.sparta.moim.common.page.Pagination;
 import com.sparta.moim.organization.domain.entity.Organization;
+import java.util.List;
 import java.util.Optional;
 
 public interface OrganizationRepository {
@@ -9,4 +10,6 @@ public interface OrganizationRepository {
     Optional<Organization> findByTrackingId(String organizationTrackingId);
     Pagination<Organization> findAll(int page, int size);
     boolean existsByTrackingId(String organizationTrackingId);
+
+    void saveAll(List<Organization> organizations);
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationRepositoryImpl.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/repository/OrganizationRepositoryImpl.java
@@ -43,4 +43,9 @@ public class OrganizationRepositoryImpl implements OrganizationRepository {
     public boolean existsByTrackingId(String organizationTrackingId) {
         return jpaRepository.existsByTrackingId(UUID.fromString(organizationTrackingId));
     }
+
+    @Override
+    public void saveAll(List<Organization> organizations) {
+        jpaRepository.saveAll(organizations);
+    }
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/DataCreateService.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/DataCreateService.java
@@ -8,7 +8,9 @@ import com.sparta.moim.organization.domain.repository.OrganizationMemberReposito
 import com.sparta.moim.organization.domain.repository.OrganizationRepository;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,10 +52,15 @@ public class DataCreateService {
             // 역할 배분
             int managerCount = (int) (memberCount * 0.2);
             int memberCountOnly = memberCount - managerCount - 1; // 나머지 MEMBER, MASTER 1명
-
+            Set<String> usedUserIds = new HashSet<>();
             for (int j = 0; j < memberCount; j++) {
                 long userIndex = ((long)(orgStartIndex + i)) * 10_000 + j;
                 String paddedId = String.format("%06d", userIndex % 100_000);
+                // 중복 방지 로직
+                while (!usedUserIds.add(paddedId)) {
+                    userIndex++;
+                    paddedId = String.format("%06d", userIndex % 100_000);
+                }
                 UUID userTrackingId = UUID.nameUUIDFromBytes(("user-" + paddedId).getBytes());
 
                 OrganizationMemberRole role;

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/DataCreateService.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/DataCreateService.java
@@ -1,0 +1,94 @@
+package com.sparta.moim.organization.infrastruct.util;
+
+import com.github.javafaker.Faker;
+import com.sparta.moim.organization.domain.entity.Organization;
+import com.sparta.moim.organization.domain.entity.OrganizationMember;
+import com.sparta.moim.organization.domain.enums.OrganizationMemberRole;
+import com.sparta.moim.organization.domain.repository.OrganizationMemberRepository;
+import com.sparta.moim.organization.domain.repository.OrganizationRepository;
+import jakarta.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DataCreateService {
+
+    private final OrganizationRepository organizationRepository;
+    private final OrganizationMemberRepository organizationMemberRepository;
+    private static final Faker faker = new Faker();
+
+    @Transactional
+    public void generateOrganizationBatch(int batchNumber, int batchSize, int organizationTotalCount) {
+        List<Organization> organizations = new ArrayList<>();
+        List<OrganizationMember> members = new ArrayList<>();
+
+        int orgStartIndex = batchNumber * batchSize;
+        for (int i = 0; i < batchSize; i++) {
+            int orgIndex = orgStartIndex + i;
+            Organization organization = Organization.builder()
+                    .trackingId(UUID.randomUUID())
+                    .organizationName("모임_" + orgIndex)
+                    .description(faker.lorem().sentence())
+                    .build();
+            organizations.add(organization);
+        }
+
+        organizationRepository.saveAll(organizations);
+
+        // 멤버 생성
+        int totalMembers = 0;
+        for (int i = 0; i < batchSize; i++) {
+            Organization org = organizations.get(i);
+            int memberCount = getMemberCountForOrganization(orgStartIndex + i, organizationTotalCount);
+
+            // 역할 배분
+            int managerCount = (int) (memberCount * 0.2);
+            int memberCountOnly = memberCount - managerCount - 1; // 나머지 MEMBER, MASTER 1명
+
+            for (int j = 0; j < memberCount; j++) {
+                long userIndex = ((long)(orgStartIndex + i)) * 10_000 + j;
+                String paddedId = String.format("%06d", userIndex % 100_000);
+                UUID userTrackingId = UUID.nameUUIDFromBytes(("user-" + paddedId).getBytes());
+
+                OrganizationMemberRole role;
+                if (j == 0) {
+                    role = OrganizationMemberRole.MASTER; // 1명만
+                } else if (j <= managerCount) {
+                    role = OrganizationMemberRole.MANAGER; // 20% 관리자
+                } else {
+                    role = OrganizationMemberRole.MEMBER; // 나머지 80% 일반 멤버
+                }
+
+                OrganizationMember member = OrganizationMember.builder()
+                        .trackingId(UUID.randomUUID())
+                        .userTrackingId(userTrackingId)
+                        .nickname(faker.name().username())
+                        .role(role)
+                        .organization(org)
+                        .build();
+                members.add(member);
+            }
+
+            totalMembers += memberCount;
+        }
+
+        organizationMemberRepository.saveAll(members);
+
+        log.info("✅ 조직 batch[{}] - 조직 {}개 / 멤버 {}명 생성 완료", batchNumber, batchSize, totalMembers);
+    }
+
+    private int getMemberCountForOrganization(int orgIndex, int totalCount) {
+        int quarter = totalCount / 4;
+
+        if (orgIndex < quarter) return 10_000;
+        if (orgIndex < quarter * 2) return 5_000;
+        if (orgIndex < quarter * 3) return 1_000;
+        return 500;
+    }
+}

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/MockDataInitializer.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/MockDataInitializer.java
@@ -24,8 +24,8 @@ public class MockDataInitializer implements ApplicationRunner {
     private final OrganizationMemberRepository organizationMemberRepository;
     private final DataCreateService dataCreateService;
 
-    private static final int TOTAL_ORGANIZATIONS = 10_000;
-    private static final int ORG_BATCH_SIZE = 1_000;
+    private static final int TOTAL_ORGANIZATIONS = 100;
+    private static final int ORG_BATCH_SIZE = 10;
     private static final int THREAD_POOL_SIZE = 10;
 
     @Override

--- a/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/MockDataInitializer.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/infrastruct/util/MockDataInitializer.java
@@ -1,0 +1,57 @@
+package com.sparta.moim.organization.infrastruct.util;
+
+import com.sparta.moim.organization.domain.repository.OrganizationMemberRepository;
+import com.sparta.moim.organization.domain.repository.OrganizationRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableAsync
+@Slf4j
+@RequiredArgsConstructor
+public class MockDataInitializer implements ApplicationRunner {
+
+    private final OrganizationRepository organizationRepository;
+    private final OrganizationMemberRepository organizationMemberRepository;
+    private final DataCreateService dataCreateService;
+
+    private static final int TOTAL_ORGANIZATIONS = 10_000;
+    private static final int ORG_BATCH_SIZE = 1_000;
+    private static final int THREAD_POOL_SIZE = 10;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (organizationRepository.findAll(0, 1).getTotal()>0) {
+            log.info("이미 데이터가 존재합니다.");
+            return;
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        long start = System.currentTimeMillis();
+
+        for (int batch = 0; batch < TOTAL_ORGANIZATIONS / ORG_BATCH_SIZE; batch++) {
+            int finalBatch = batch;
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() ->
+                    dataCreateService.generateOrganizationBatch(finalBatch, ORG_BATCH_SIZE, TOTAL_ORGANIZATIONS), executor);
+            futures.add(future);
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+
+        long total = System.currentTimeMillis() - start;
+        log.info("✅ 모든 조직 및 멤버 데이터 생성 완료 (소요 시간: {}ms)", total);
+
+        executor.shutdown();
+    }
+}

--- a/organization-service/src/main/resources/application.yml
+++ b/organization-service/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
 
 eureka:

--- a/organization-service/src/main/resources/application.yml
+++ b/organization-service/src/main/resources/application.yml
@@ -14,7 +14,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
 
 eureka:


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
- AppliationRunner로 서버 실행시 목데이터 넣도록 수정

### 2️⃣ 변경 이유
- 대규모 시스템이므로 테스트시 성능 테스트를 명확하게 하기 위해서

### 3️⃣ 추가 설명
- 서버실행시 OrganizationRepository에 아무런 모임이 존재하지 않을경우 실행됩니다.
- 모임 100개, 모임멤버 41200개가 생성됩니다.
- 대략 3분정도 소요됩니다.

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 조직 및 조직원 더미 데이터를 대량으로 생성하는 서비스와 초기화 기능이 추가되었습니다.
    - 애플리케이션 시작 시 조직 데이터가 없을 경우, 자동으로 100개의 조직과 다양한 규모의 조직원을 비동기로 생성합니다.

- **버그 수정**
    - 조직 및 조직원 엔티티의 생성자와 빌더 접근 제한이 완화되어 테스트 및 데이터 생성이 용이해졌습니다.

- **기타**
    - 더미 데이터 생성을 위한 외부 라이브러리(javafaker, snakeyaml)가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->