### PR TITLE
[Gathering] 맴버 관리를 userName아닌 userId로 변경

### DIFF
--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/CreateGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/CreateGatheringCommand.java
@@ -1,13 +1,14 @@
 package com.sparta.moim.gathering.gathering.application.dto.command;
 
 import com.sparta.moim.gathering.gathering.domain.entity.Gathering;
+import java.util.UUID;
 import lombok.Builder;
 
 @Builder
 public record CreateGatheringCommand(
     String organizationId,
     String name,
-    String owner,
+    UUID owner,
     int count,
     boolean status
 ) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/UpdateGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/UpdateGatheringCommand.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 @Builder
 public record UpdateGatheringCommand(
     UUID gatheringId,
-    String owner,
+    UUID owner,
     String name,
     int count,
     Boolean status) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/JoinGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/JoinGatheringCommand.java
@@ -8,7 +8,7 @@ import com.sparta.moim.gathering.shared.enums.MemberType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record JoinGatheringCommand(UUID gatheringId, UUID username) {
+public record JoinGatheringCommand(UUID gatheringId, UUID userId) {
 
   public JoinGatheringCommand(UUID gatheringId, CustomUserDetails userInfo) {
     this(gatheringId, userInfo.getTrackingId());
@@ -17,7 +17,7 @@ public record JoinGatheringCommand(UUID gatheringId, UUID username) {
   public Member toDomain() {
     return Member.builder()
         .gatheringId(gatheringId)
-        .memberId(username)
+        .memberId(userId)
         .type(MemberType.GENERAL)
         .joinTime(LocalDateTime.now())
         .build();

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/JoinGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/JoinGatheringCommand.java
@@ -8,10 +8,10 @@ import com.sparta.moim.gathering.shared.enums.MemberType;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-public record JoinGatheringCommand(UUID gatheringId, String username) {
+public record JoinGatheringCommand(UUID gatheringId, UUID username) {
 
   public JoinGatheringCommand(UUID gatheringId, CustomUserDetails userInfo) {
-    this(gatheringId, userInfo.getUsername());
+    this(gatheringId, userInfo.getTrackingId());
   }
 
   public Member toDomain() {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/LeaveGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/LeaveGatheringCommand.java
@@ -5,9 +5,9 @@ import com.sparta.moim.gathering.gathering.domain.dto.criteria.GatheringEventCri
 import com.sparta.moim.gathering.shared.enums.EventType;
 import java.util.UUID;
 
-public record LeaveGatheringCommand(UUID gatheringId, String username) {
+public record LeaveGatheringCommand(UUID gatheringId, UUID username) {
   public LeaveGatheringCommand(UUID gatheringId, CustomUserDetails userInfo) {
-    this(gatheringId, userInfo.getUsername());
+    this(gatheringId, userInfo.getTrackingId());
   }
 
   public GatheringEventCriteria toEventCriteria(String streamLeaveKey, EventType eventType, String payload) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/LeaveGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/LeaveGatheringCommand.java
@@ -5,7 +5,7 @@ import com.sparta.moim.gathering.gathering.domain.dto.criteria.GatheringEventCri
 import com.sparta.moim.gathering.shared.enums.EventType;
 import java.util.UUID;
 
-public record LeaveGatheringCommand(UUID gatheringId, UUID username) {
+public record LeaveGatheringCommand(UUID gatheringId, UUID userId) {
   public LeaveGatheringCommand(UUID gatheringId, CustomUserDetails userInfo) {
     this(gatheringId, userInfo.getTrackingId());
   }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/RemoveGatheringCommand.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/command/event/RemoveGatheringCommand.java
@@ -5,7 +5,7 @@ import java.util.UUID;
 
 public record RemoveGatheringCommand(
     UUID gatheringId,
-    List<String> users,
-    String memberId
+    List<UUID> users,
+    UUID memberId
 ) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAddAdminEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringAddAdminEvent.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record GatheringAddAdminEvent(UUID gatheringId, String memberName, String type) {
+public record GatheringAddAdminEvent(UUID gatheringId, UUID memberName, String type) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringRevokeAdminEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringRevokeAdminEvent.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record GatheringRevokeAdminEvent(UUID gatheringId, String ownerName) {
+public record GatheringRevokeAdminEvent(UUID gatheringId, UUID ownerName) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringRevokeAdminEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/GatheringRevokeAdminEvent.java
@@ -4,5 +4,5 @@ import java.util.UUID;
 import lombok.Builder;
 
 @Builder
-public record GatheringRevokeAdminEvent(UUID gatheringId, UUID ownerName) {
+public record GatheringRevokeAdminEvent(UUID gatheringId, UUID ownerId) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/redis/GatheringJoinAdminEvent.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/event/redis/GatheringJoinAdminEvent.java
@@ -13,17 +13,17 @@ import lombok.NoArgsConstructor;
 @Getter
 public class GatheringJoinAdminEvent {
   private static final String KEY_GATHERING_ID = "gathering_id";
-  private static final String KEY_MEMBER_NAME = "member_name";
+  private static final String KEY_MEMBER_ID = "member_id";
   private static final String KEY_TYPE = "type";
 
   private UUID gatheringId;
-  private String memberName;
+  private UUID memberId;
   private MemberType type;
 
   public Map<String, String> toMap() {
     Map<String, String> map = new HashMap<>();
     map.put(KEY_GATHERING_ID, gatheringId.toString());
-    map.put(KEY_MEMBER_NAME, memberName);
+    map.put(KEY_MEMBER_ID, memberId.toString());
     map.put(KEY_TYPE, type.name());
     return map;
   }
@@ -31,7 +31,7 @@ public class GatheringJoinAdminEvent {
   public static GatheringJoinAdminEvent fromMap(Map<String, String> map) {
     return new GatheringJoinAdminEvent(
         UUID.fromString(map.get(KEY_GATHERING_ID)),
-        map.get(KEY_MEMBER_NAME),
+        UUID.fromString(map.get(KEY_MEMBER_ID)),
         MemberType.valueOf(map.get(KEY_TYPE)));
   }
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/CreateGatheringResult.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/CreateGatheringResult.java
@@ -7,7 +7,7 @@ public record CreateGatheringResult(
     UUID gatheringId,
     String organizationId,
     String name,
-    String owner,
+    UUID owner,
     int count,
     boolean status
 ) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetGatheringMemberListResult.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetGatheringMemberListResult.java
@@ -1,9 +1,10 @@
 package com.sparta.moim.gathering.gathering.application.dto.result;
 
 import com.sparta.moim.gathering.gathering.domain.entity.Member;
+import java.util.UUID;
 
 public record GetGatheringMemberListResult(
-    String name,
+    UUID name,
     String type
 ) {
   public GetGatheringMemberListResult(Member member) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetGatheringResult.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetGatheringResult.java
@@ -9,7 +9,7 @@ public record GetGatheringResult(
     UUID gatheringId,
     String organizationId,
     String name,
-    String owner,
+    UUID owner,
     int count,
     boolean status,
     List<GetGatheringMemberListResult> members,

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetMemberListResult.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/dto/result/GetMemberListResult.java
@@ -1,5 +1,7 @@
 package com.sparta.moim.gathering.gathering.application.dto.result;
 
-public record GetMemberListResult(String name,
+import java.util.UUID;
+
+public record GetMemberListResult(UUID name,
                                   String type) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/event/publisher/MemberPublisher.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/event/publisher/MemberPublisher.java
@@ -3,7 +3,7 @@ package com.sparta.moim.gathering.gathering.application.event.publisher;
 import java.util.UUID;
 
 public interface MemberPublisher {
-  void add(UUID gatheringId, String memberName);
+  void add(UUID gatheringId, UUID memberName);
 
-  void revoke(UUID id, String owner);
+  void revoke(UUID id, UUID owner);
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRdsProxyService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRdsProxyService.java
@@ -27,7 +27,7 @@ public class MemberRdsProxyService implements MemberService {
   @Transactional
   public void leaveGathering(LeaveGatheringCommand command) {
     memberServiceStruct.leaveGathering(command);
-    memberRepository.deleteByGatheringIdAndMemberId(command.gatheringId(), command.username());
+    memberRepository.deleteByGatheringIdAndMemberId(command.gatheringId(), command.userId());
   }
 
   @Override

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRedisProxyService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRedisProxyService.java
@@ -52,7 +52,7 @@ public class MemberRedisProxyService implements MemberService {
   public void leaveGathering(LeaveGatheringCommand command) {
     Map<String, String> map = Map.of(
         "gathering_id", command.gatheringId().toString(),
-        "member_name", command.username().toString()
+        "member_id", command.userId().toString()
     );
 
     memberServiceStruct.leaveGathering(command);

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRedisProxyService.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/proxy/MemberRedisProxyService.java
@@ -52,7 +52,7 @@ public class MemberRedisProxyService implements MemberService {
   public void leaveGathering(LeaveGatheringCommand command) {
     Map<String, String> map = Map.of(
         "gathering_id", command.gatheringId().toString(),
-        "member_name", command.username()
+        "member_name", command.username().toString()
     );
 
     memberServiceStruct.leaveGathering(command);

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/struct/MemberServiceStruct.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/struct/MemberServiceStruct.java
@@ -26,7 +26,7 @@ public class MemberServiceStruct {
     validateGatheringExists(command.gatheringId());
     statusTrueValidate(command);
 
-    if (memberRepository.existsByGatheringIdAndMemberId(command.gatheringId(), command.username())) {
+    if (memberRepository.existsByGatheringIdAndMemberId(command.gatheringId(), command.userId())) {
       throw new AlreadyParticipateFoundGatheringException();
     }
 
@@ -42,9 +42,9 @@ public class MemberServiceStruct {
     validateGatheringExists(command.gatheringId());
 
     UUID gatheringId = command.gatheringId();
-    UUID username = command.username();
+    UUID userId = command.userId();
 
-    if (!memberRepository.existsByGatheringIdAndMemberId(gatheringId, username)) {
+    if (!memberRepository.existsByGatheringIdAndMemberId(gatheringId, userId)) {
       throw new NotFoundGatheringMemberException();
     }
 

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/struct/MemberServiceStruct.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/application/service/struct/MemberServiceStruct.java
@@ -42,7 +42,7 @@ public class MemberServiceStruct {
     validateGatheringExists(command.gatheringId());
 
     UUID gatheringId = command.gatheringId();
-    String username = command.username();
+    UUID username = command.username();
 
     if (!memberRepository.existsByGatheringIdAndMemberId(gatheringId, username)) {
       throw new NotFoundGatheringMemberException();

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Gathering.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Gathering.java
@@ -35,7 +35,7 @@ public class Gathering extends BaseEntity {
 
   private String organizationId;
 
-  private String owner;
+  private UUID owner;
 
   private int count;
 
@@ -46,7 +46,7 @@ public class Gathering extends BaseEntity {
   @Column(length = 36, nullable = false, unique = true)
   private UUID trackingId;
 
-  public static Gathering create(String organizationId, String name, String owner, int count, boolean status) {
+  public static Gathering create(String organizationId, String name, UUID owner, int count, boolean status) {
     return Gathering.builder()
         .count(count)
         .organizationId(organizationId)
@@ -57,7 +57,7 @@ public class Gathering extends BaseEntity {
 
   }
 
-  public static Gathering update(UUID gatheringId, String owner, String name, int count, Boolean status) {
+  public static Gathering update(UUID gatheringId, UUID owner, String name, int count, Boolean status) {
     return Gathering.builder()
         .count(count)
         .owner(owner)

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
@@ -40,7 +40,7 @@ public class Member {
   @Column(length = 36, nullable = false)
   private UUID gatheringId;
 
-  private String memberId;
+  private UUID memberId;
 
   @Enumerated(EnumType.STRING)
   private MemberType type;
@@ -56,14 +56,14 @@ public class Member {
         .build();
   }
 
-  public void changeOwner(String memberId) {
+  public void changeOwner(UUID memberId) {
     this.memberId = memberId;
   }
 
   public Map<String, String> toMap() {
     Map<String, String> map = new HashMap<>();
     map.put("gathering_id", gatheringId.toString());
-    map.put("member_name", memberId);
+    map.put("member_name", memberId.toString());
     map.put("type", MemberType.GENERAL.name());
     return map;
   }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/entity/Member.java
@@ -63,7 +63,7 @@ public class Member {
   public Map<String, String> toMap() {
     Map<String, String> map = new HashMap<>();
     map.put("gathering_id", gatheringId.toString());
-    map.put("member_name", memberId.toString());
+    map.put("member_id", memberId.toString());
     map.put("type", MemberType.GENERAL.name());
     return map;
   }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/repository/MemberRepository.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/domain/repository/MemberRepository.java
@@ -9,17 +9,17 @@ import java.util.UUID;
 public interface MemberRepository {
   Member save(Member member);
 
-  void deleteByGatheringIdAndMemberId(UUID gatheringId, String memberId);
+  void deleteByGatheringIdAndMemberId(UUID gatheringId, UUID memberId);
 
-  void deleteAllByGatheringIdAndMembers(UUID gatheringId, List<String> memberIds);
+  void deleteAllByGatheringIdAndMembers(UUID gatheringId, List<UUID> memberIds);
 
   List<Member> findMembers(UUID gatheringId);
 
-  boolean existsByGatheringIdAndMemberId(UUID gatheringId, String memberId);
+  boolean existsByGatheringIdAndMemberId(UUID gatheringId, UUID memberId);
 
-  MemberType findMemberType(UUID gatheringId, String memberId);
+  MemberType findMemberType(UUID gatheringId, UUID memberId);
 
-  Optional<Member> findByMemberStatusOwner(UUID gatheringId, String memberId);
+  Optional<Member> findByMemberStatusOwner(UUID gatheringId, UUID memberId);
 
   Optional<Member> existsOwner(UUID gatheringId);
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamJoinListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamJoinListener.java
@@ -26,7 +26,7 @@ public class RedisStreamJoinListener implements StreamListener<String, MapRecord
 
     memberRepository.save(Member.builder()
         .gatheringId(gatheringId)
-        .memberId(UUID.fromString(message.getValue().get("member_name")))
+        .memberId(UUID.fromString(message.getValue().get("member_id")))
         .type(MemberType.valueOf(message.getValue().get("type")))
         .joinTime(LocalDateTime.now())
         .build());

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamJoinListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamJoinListener.java
@@ -26,7 +26,7 @@ public class RedisStreamJoinListener implements StreamListener<String, MapRecord
 
     memberRepository.save(Member.builder()
         .gatheringId(gatheringId)
-        .memberId(message.getValue().get("member_name"))
+        .memberId(UUID.fromString(message.getValue().get("member_name")))
         .type(MemberType.valueOf(message.getValue().get("type")))
         .joinTime(LocalDateTime.now())
         .build());

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamLeaveListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamLeaveListener.java
@@ -21,7 +21,7 @@ public class RedisStreamLeaveListener implements StreamListener<String, MapRecor
   public void onMessage(MapRecord<String, String, String> message) {
     try {
       UUID gatheringId = UUID.fromString(message.getValue().get("gathering_id"));
-      String memberName = message.getValue().get("member_name");
+      UUID memberName = UUID.fromString(message.getValue().get("member_name"));
       log.info("멤버 퇴장 이벤트 수신: gatheringId={}, memberName={}", gatheringId, memberName);
       memberRepository.deleteByGatheringIdAndMemberId(gatheringId, memberName);
     } catch (Exception e) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamLeaveListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RedisStreamLeaveListener.java
@@ -21,9 +21,9 @@ public class RedisStreamLeaveListener implements StreamListener<String, MapRecor
   public void onMessage(MapRecord<String, String, String> message) {
     try {
       UUID gatheringId = UUID.fromString(message.getValue().get("gathering_id"));
-      UUID memberName = UUID.fromString(message.getValue().get("member_name"));
-      log.info("멤버 퇴장 이벤트 수신: gatheringId={}, memberName={}", gatheringId, memberName);
-      memberRepository.deleteByGatheringIdAndMemberId(gatheringId, memberName);
+      UUID memberId = UUID.fromString(message.getValue().get("member_id"));
+      log.info("멤버 퇴장 이벤트 수신: gatheringId={}, memberId={}", gatheringId, memberId);
+      memberRepository.deleteByGatheringIdAndMemberId(gatheringId, memberId);
     } catch (Exception e) {
       log.error("멤버 퇴장 처리 중 오류 발생: {}", e.getMessage(), e);
       throw new MemberLeaveProcessingException();

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RevokeGatheringMemberListener.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/listener/RevokeGatheringMemberListener.java
@@ -19,10 +19,10 @@ public class RevokeGatheringMemberListener {
   @EventListener
   @Transactional
   public void revoke(GatheringRevokeAdminEvent revokeMember) {
-    Member member = memberRepository.findByMemberStatusOwner(revokeMember.gatheringId(), revokeMember.ownerName())
+    Member member = memberRepository.findByMemberStatusOwner(revokeMember.gatheringId(), revokeMember.ownerId())
         .orElseThrow(NotFoundGatheringMemberException::new);
-    member.changeOwner(revokeMember.ownerName());
-    log.info("소모임 관리자 수정 완료: {}", revokeMember.ownerName());
+    member.changeOwner(revokeMember.ownerId());
+    log.info("소모임 관리자 수정 완료: {}", revokeMember.ownerId());
   }
 
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherEventStream.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherEventStream.java
@@ -26,7 +26,7 @@ public class MemberPublisherEventStream implements MemberPublisher {
   public void revoke(UUID gatheringId, UUID owner) {
     publisher.publishEvent(GatheringRevokeAdminEvent.builder()
         .gatheringId(gatheringId)
-        .ownerName(owner)
+        .ownerId(owner)
         .build());
   }
 

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherEventStream.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/event/publisher/MemberPublisherEventStream.java
@@ -14,7 +14,7 @@ public class MemberPublisherEventStream implements MemberPublisher {
   private final ApplicationEventPublisher publisher;
 
   @Override
-  public void add(UUID gatheringId, String memberName) {
+  public void add(UUID gatheringId, UUID memberName) {
     publisher.publishEvent(GatheringAddAdminEvent.builder()
         .gatheringId(gatheringId)
         .memberName(memberName)
@@ -23,7 +23,7 @@ public class MemberPublisherEventStream implements MemberPublisher {
   }
 
   @Override
-  public void revoke(UUID gatheringId, String owner) {
+  public void revoke(UUID gatheringId, UUID owner) {
     publisher.publishEvent(GatheringRevokeAdminEvent.builder()
         .gatheringId(gatheringId)
         .ownerName(owner)

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/repository/GatheringRepositoryRepositoryCustomImpl.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/repository/GatheringRepositoryRepositoryCustomImpl.java
@@ -9,6 +9,7 @@ import com.sparta.moim.gathering.gathering.domain.entity.QGathering;
 import com.sparta.moim.gathering.gathering.domain.repository.GatheringRepositoryCustom;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -20,13 +21,11 @@ public class GatheringRepositoryRepositoryCustomImpl implements GatheringReposit
 
   @Override
   public Pagination<Gathering> searchGathering(SearchGatheringCriteria criteria) {
-    String username = criteria.username();
-    String role = criteria.role();
-    List<Long> gatheringIds = findGatheringIds(username, role);
+//    List<Long> gatheringIds = findGatheringIds(username, role);
 
     List<Gathering> content = query.select(gathering)
         .where(
-            nullCheckGatheringId(gatheringIds),
+//            nullCheckGatheringId(gatheringIds),
             gathering.status.eq(criteria.status()),
             nullCheckStartTime(criteria.startTime(), criteria.endTime()),
             nullCheckGatheringDeleted(criteria.isDeleted(), criteria.role())
@@ -39,7 +38,7 @@ public class GatheringRepositoryRepositoryCustomImpl implements GatheringReposit
 
     Long total = query.select(gathering.count())
         .where(
-            nullCheckGatheringId(gatheringIds),
+//            nullCheckGatheringId(gatheringIds),
             gathering.status.eq(criteria.status()),
             nullCheckStartTime(criteria.startTime(), criteria.endTime()),
             nullCheckGatheringDeleted(criteria.isDeleted(), criteria.role()))
@@ -77,7 +76,7 @@ public class GatheringRepositoryRepositoryCustomImpl implements GatheringReposit
     return gatheringIds == null ? null : gathering.id.in(gatheringIds);
   }
 
-  private List<Long> findGatheringIds(String username, String role) {
+  private List<Long> findGatheringIds(UUID username, String role) {
     if (role == null || "USER".equals(role)) {
       return null;
     }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/repository/JpaMemberRepository.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/infrastructure/repository/JpaMemberRepository.java
@@ -16,18 +16,18 @@ public interface JpaMemberRepository extends JpaRepository<Member, Long>, Member
   @Modifying
   @Query("delete from Member m where m.gatheringId = :gatheringId and m.memberId IN (:memberIds)")
   void deleteAllByGatheringIdAndMembers(@Param("gatheringId") UUID gatheringId,
-                                        @Param("memberIds") List<String> memberIds);
+                                        @Param("memberIds") List<UUID> memberIds);
 
   @Query("select m from Member m where m.gatheringId = :gatheringId")
   List<Member> findMembers(@Param("gatheringId") UUID gatheringId);
 
   @Query("select m.type from Member m where m.gatheringId = :gatheringId and m.memberId = :memberId")
-  MemberType findMemberType(@Param("gatheringId") UUID gatheringId, @Param("memberId") String memberId);
+  MemberType findMemberType(@Param("gatheringId") UUID gatheringId, @Param("memberId") UUID memberId);
 
   @Query("""
       select m from Member m where m.gatheringId = :gatheringId  and m.memberId <> :memberId
       """)
-  Optional<Member> findByMemberStatusOwner(@Param("gatheringId") UUID gatheringId, @Param("memberId") String memberId);
+  Optional<Member> findByMemberStatusOwner(@Param("gatheringId") UUID gatheringId, @Param("memberId") UUID memberId);
 
 
   @Query(""" 

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/MemberController.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/MemberController.java
@@ -43,7 +43,7 @@ public class MemberController {
   public ResponseEntity<ApiResponseData<Void>> removeGathering(@PathVariable UUID gatheringId,
                                                                @RequestBody @Valid RemoveGatheringRequest request,
                                                                @AuthenticationPrincipal CustomUserDetails details) {
-    memberService.removeGathering(request.toCommand(gatheringId, details.getUsername()));
+    memberService.removeGathering(request.toCommand(gatheringId, details.getTrackingId()));
     return ResponseEntity.ok(ApiResponseData.success(null));
   }
 

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/CreateGatheringRequest.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/CreateGatheringRequest.java
@@ -4,11 +4,12 @@ import com.sparta.moim.gathering.gathering.application.dto.command.CreateGatheri
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.UUID;
 
 public record CreateGatheringRequest(
     @NotNull String organizationId,
     @NotNull String name,
-    @NotNull String owner,
+    @NotNull UUID owner,
     @Positive int count,
     @Nullable Boolean status
 ) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/RemoveGatheringRequest.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/RemoveGatheringRequest.java
@@ -10,9 +10,9 @@ import java.util.UUID;
 public record RemoveGatheringRequest(
     @NotNull
     @Size(min = 1, message = "At least one user must be specified")
-    List<@NotBlank String> users
+    List<UUID> users
 ) {
-  public RemoveGatheringCommand toCommand(UUID gatheringId, String memberId) {
+  public RemoveGatheringCommand toCommand(UUID gatheringId, UUID memberId) {
     return new RemoveGatheringCommand(gatheringId, users, memberId);
   }
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/RemoveGatheringRequest.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/RemoveGatheringRequest.java
@@ -1,7 +1,6 @@
 package com.sparta.moim.gathering.gathering.presentation.dto.request;
 
 import com.sparta.moim.gathering.gathering.application.dto.command.event.RemoveGatheringCommand;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/UpdateGatheringRequest.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/request/UpdateGatheringRequest.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 @Builder
 public record UpdateGatheringRequest(
     @Nullable String name,
-    @Nullable String owner,
+    @Nullable UUID owner,
     @Positive int count,
     @Nullable Boolean status
 ) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/CreateGatheringResponse.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/CreateGatheringResponse.java
@@ -7,7 +7,7 @@ public record CreateGatheringResponse(
     UUID gatheringId,
     String organizationId,
     String name,
-    String owner,
+    UUID owner,
     int count,
     boolean status
 ) {

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetGatheringMemberListResponse.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetGatheringMemberListResponse.java
@@ -1,7 +1,9 @@
 package com.sparta.moim.gathering.gathering.presentation.dto.response;
 
+import java.util.UUID;
+
 public record GetGatheringMemberListResponse(
-    String memberId,
+    UUID memberId,
     String type
 ) {
 }

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetGatheringResponse.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetGatheringResponse.java
@@ -9,7 +9,7 @@ public record GetGatheringResponse(
     UUID gatheringId,
     String organizationId,
     String name,
-    String owner,
+    UUID owner,
     int count,
     boolean status,
     List<GetGatheringMemberListResponse> member,

--- a/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetMemberListResponse.java
+++ b/gathering-service/src/main/java/com/sparta/moim/gathering/gathering/presentation/dto/response/GetMemberListResponse.java
@@ -1,7 +1,9 @@
 package com.sparta.moim.gathering.gathering.presentation.dto.response;
 
+import java.util.UUID;
+
 public record GetMemberListResponse(
-    String name,
+    UUID name,
     String type
 ) {
 }

--- a/gathering-service/src/test/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/GatheringControllerTest.java
+++ b/gathering-service/src/test/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/GatheringControllerTest.java
@@ -77,7 +77,7 @@ class GatheringControllerTest {
     CreateGatheringCommand request = new CreateGatheringCommand(
         "org123",
         "테스트 모임",
-        "주인장",
+        UUID.randomUUID(),
         10,
         true
     );
@@ -92,11 +92,12 @@ class GatheringControllerTest {
     @DisplayName("게더링 생성 성공")
     void createGathering_success() throws Exception {
       // given
+      UUID owner = UUID.randomUUID();
       CreateGatheringResult response = new CreateGatheringResult(
           gatheringId,
           "org123",
           "테스트 모임",
-          "주인장",
+          owner,
           10,
           true
       );
@@ -114,7 +115,7 @@ class GatheringControllerTest {
           .andExpect(jsonPath("$.data.gatheringId").value(gatheringId.toString()))
           .andExpect(jsonPath("$.data.organizationId").value("org123"))
           .andExpect(jsonPath("$.data.name").value("테스트 모임"))
-          .andExpect(jsonPath("$.data.owner").value("주인장"))
+          .andExpect(jsonPath("$.data.owner").value(owner.toString()))
           .andExpect(jsonPath("$.data.count").value(10))
           .andExpect(jsonPath("$.data.status").value(true))
           .andDo(document("소모임 - 생성",
@@ -180,7 +181,7 @@ class GatheringControllerTest {
       CreateGatheringCommand request = new CreateGatheringCommand(
           "org123",
           "테스트 모임",
-          "주인장",
+          UUID.randomUUID(),
           0,
           true
       );
@@ -221,7 +222,7 @@ class GatheringControllerTest {
     UUID gatheringId = UUID.randomUUID();
     UpdateGatheringRequest request = new UpdateGatheringRequest(
         "수정된 모임 이름",
-        "chnaged",
+        UUID.randomUUID(),
         20,
         false
     );
@@ -374,14 +375,16 @@ class GatheringControllerTest {
       // given
       UUID gatheringId = UUID.randomUUID();
 
+      UUID userId = UUID.randomUUID();
+      UUID owner = UUID.randomUUID();
       List<GetGatheringMemberListResult> members = List.of(
-          new GetGatheringMemberListResult("abc", "ADMIN"));
+          new GetGatheringMemberListResult(owner, "ADMIN"));
 
       GetGatheringResult response = new GetGatheringResult(
           gatheringId,
           "org123",
           "테스트 모임",
-          "테스트유저",
+          owner,
           10,
           true,
           members,
@@ -403,9 +406,9 @@ class GatheringControllerTest {
           .andExpect(jsonPath("$.data.gatheringId").value(gatheringId.toString()))
           .andExpect(jsonPath("$.data.organizationId").value("org123"))
           .andExpect(jsonPath("$.data.name").value("테스트 모임"))
-          .andExpect(jsonPath("$.data.member[0].memberId").value("abc"))
+          .andExpect(jsonPath("$.data.member[0].memberId").value(owner.toString()))
           .andExpect(jsonPath("$.data.member[0].type").value("ADMIN"))
-          .andExpect(jsonPath("$.data.owner").value("테스트유저"))
+          .andExpect(jsonPath("$.data.owner").value(owner.toString()))
           .andExpect(jsonPath("$.data.count").value(10))
           .andExpect(jsonPath("$.data.status").value(true))
           .andDo(document("소모임 - 단일 조회",

--- a/gathering-service/src/test/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/MemberControllerTest.java
+++ b/gathering-service/src/test/java/com/sparta/moim/gathering/gathering/presentation/contoller/external/MemberControllerTest.java
@@ -135,7 +135,7 @@ class MemberControllerTest {
     UUID userId = UUID.randomUUID();
     String role = "USER";
 
-    RemoveGatheringRequest request = new RemoveGatheringRequest(List.of("deleteUser"));
+    RemoveGatheringRequest request = new RemoveGatheringRequest(List.of(UUID.randomUUID()));
 
     setupSecurityContext(username, role, userId);
 


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
맴버 관리를 userName아닌 userId로 변경

### 2️⃣ 변경 이유
user데이터 조회시 userName이 아닌 userId로 조회가 되어지기 때문

### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - 사용자, 소유자, 멤버 식별자 관련 필드와 파라미터의 데이터 타입이 String에서 UUID로 일괄 변경되었습니다. 이로 인해 요청/응답, 도메인, 이벤트, 서비스, 저장소 등 전반에서 UUID 기반의 식별 방식이 적용됩니다.

- **Tests**
  - 테스트 코드에서도 모든 사용자 및 멤버 식별자가 UUID로 변경되어, 관련 요청/응답 및 검증 로직이 UUID에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->