### PR TITLE
[User] 리프래시 토큰 저장 및 관리(DB: Redis 사용)

### DIFF
--- a/gateway/src/main/java/com/sparta/moim/gateway/filter/PassportRelayFilter.java
+++ b/gateway/src/main/java/com/sparta/moim/gateway/filter/PassportRelayFilter.java
@@ -38,7 +38,7 @@ public class PassportRelayFilter extends AbstractGatewayFilterFactory<Object> {
   @Override
   public GatewayFilter apply(Object config) {
     return (exchange, chain) -> {
-      log.info("PassportRelayFilter apply");
+      log.info("PassportRelayFilter apply={}", exchange.getRequest().getPath());
       String accessToken = extractAccessTokenFromCookie(exchange);
       return webClient.get()
           .uri(GET_PASSPORT_URL)

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/user-service/http/user.http
+++ b/user-service/http/user.http
@@ -19,7 +19,8 @@ Content-Type: application/json
 
 ### logout
 POST http://localhost:19091/api/v1/users/logout
-Cookie: accessToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1YThmMzAwNC1mZWNmLTQ0ZGMtYTAzYi1jMjlkOGNiMjUzNzciLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiaXNzIjoiaHR0cHM6Ly9tb2ltLmNvbSIsImlhdCI6MTc0NTI1NTI4MCwiZXhwIjoxNzQ1MjU3MDgwfQ.k7nbNHIs2AikRzFdtUTkfMpd0-t-gbKuqYvsdWJjhh8; Path=/; Max-Age=1800; Expires=Mon, 21 Apr 2025 17:38:00 GMT; Secure; HttpOnly; SameSite=LAX
+Cookie: accessToken=eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMDIzNDBiMi0wMmMzLTRiN2MtYmYzMy02YTAwMGIyMGJkY2YiLCJzdWIiOiIwYTlkZjAyNi1jMGQzLTQ1MmMtYTQ2Zi0yMzQ1ODVlMjBlYjMiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiaXNzIjoiaHR0cHM6Ly9tb2ltLmNvbSIsImlhdCI6MTc0NTU0Nzg2NCwiZXhwIjoxNzQ1NTQ5NjY0fQ.3Mi5lFz2HRFAtHGYSI3l05xTpy2KFE1UGLEFkhD0crM; Path=/; Max-Age=1800; Expires=Fri, 25 Apr 2025 02:54:24 GMT; Secure; HttpOnly; SameSite=LAXr
+// Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiI2MmY1YjhkNy00MjRmLTQyYzQtOTI5MS00MGI1NTMxYWEyNWMiLCJzdWIiOiI2OTlkM2NjMC04MTY4LTQzYTYtYjU3Zi05ZTY1ZWNhMDQzYzUiLCJ1c2VybmFtZSI6InVzZXJuYW1lIiwiaXNzIjoiaHR0cHM6Ly9tb2ltLmNvbSIsImlhdCI6MTc0NTU0NjM2MSwiZXhwIjoxNzQ2MTUxMTYxfQ.BjLABkYOYxzqpQTh33uDNL0zRy0wTnMp3Eup36IjP5w; Path=/api/v1/auth/refresh; Max-Age=604800; Expires=Fri, 02 May 2025 01:59:21 GMT; Secure; HttpOnly; SameSite=STRICT
 
 ### 유저 조회 by TrackingId
 GET http://localhost:8082/internal/v1/users/a03730a3-9163-43ce-87db-ef40be8e6b6f

--- a/user-service/src/main/java/com/sparta/moim/user/application/AuthService.java
+++ b/user-service/src/main/java/com/sparta/moim/user/application/AuthService.java
@@ -5,7 +5,7 @@ import static com.sparta.moim.user.application.exception.UserErrorCode.USER_NOT_
 import com.sparta.moim.common.passport.Passport;
 import com.sparta.moim.user.application.exception.UserNotFoundException;
 import com.sparta.moim.user.domain.model.User;
-import com.sparta.moim.user.domain.repository.UserRepository;
+import com.sparta.moim.user.domain.UserRepository;
 import com.sparta.moim.user.infrastructure.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import java.util.UUID;

--- a/user-service/src/main/java/com/sparta/moim/user/application/UserService.java
+++ b/user-service/src/main/java/com/sparta/moim/user/application/UserService.java
@@ -10,13 +10,13 @@ import com.sparta.moim.user.application.dto.ProcessSignupCommand;
 import com.sparta.moim.user.application.dto.SignupUserResult;
 import com.sparta.moim.user.application.dto.UpdateUserCommand;
 import com.sparta.moim.user.application.dto.UpdateUserResult;
-import com.sparta.moim.user.application.dto.UserSummaryResult;
 import com.sparta.moim.user.application.dto.UserSummaryQuery;
+import com.sparta.moim.user.application.dto.UserSummaryResult;
 import com.sparta.moim.user.application.exception.AlreadyExistsUsernameException;
 import com.sparta.moim.user.application.exception.UserNotFoundException;
 import com.sparta.moim.user.application.mapper.UserDataAccessMapper;
+import com.sparta.moim.user.domain.UserRepository;
 import com.sparta.moim.user.domain.model.User;
-import com.sparta.moim.user.domain.repository.UserRepository;
 import com.sparta.moim.user.infrastructure.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import java.time.ZoneId;
@@ -68,11 +68,11 @@ public class UserService {
         .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
 
     String username = user.getUsername();
-    String role = user.getRole().name();
     UUID trackingId = user.getTrackingId();
 
+    UUID jti = UUID.randomUUID();
     ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-    String accessToken = jwtUtil.createAccessToken(username, role, trackingId, now);
+    String accessToken = jwtUtil.createAccessToken(username, trackingId, jti, now);
     ResponseCookie accessTokenCookie = jwtUtil.createAccessTokenCookie(accessToken);
 
     return new AccessTokenRefreshResult(accessTokenCookie);

--- a/user-service/src/main/java/com/sparta/moim/user/config/RedisConfig.java
+++ b/user-service/src/main/java/com/sparta/moim/user/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.sparta.moim.user.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisHost, redisPort);
+  }
+}

--- a/user-service/src/main/java/com/sparta/moim/user/constants/JwtConstants.java
+++ b/user-service/src/main/java/com/sparta/moim/user/constants/JwtConstants.java
@@ -1,0 +1,18 @@
+package com.sparta.moim.user.constants;
+
+public class JwtConstants {
+
+  public static class Expiry {
+    public static final int ACCESS_TOKEN = 60 * 30;
+    public static final int REFRESH_TOKEN = 60 * 60 * 24 * 7;
+  }
+
+  public static class CookieName {
+    public static final String ACCESS_TOKEN = "accessToken";
+    public static final String REFRESH_TOKEN = "refreshToken";
+  }
+
+  public static class Claim {
+    public static final String USERNAME = "username";
+  }
+}

--- a/user-service/src/main/java/com/sparta/moim/user/domain/UserRepository.java
+++ b/user-service/src/main/java/com/sparta/moim/user/domain/UserRepository.java
@@ -1,4 +1,4 @@
-package com.sparta.moim.user.domain.repository;
+package com.sparta.moim.user.domain;
 
 import com.sparta.moim.user.domain.model.User;
 import java.util.Optional;

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/jwt/JwtUtil.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/jwt/JwtUtil.java
@@ -7,6 +7,9 @@ import static com.sparta.moim.user.application.exception.AuthErrorCode.SIGNATURE
 import static com.sparta.moim.user.application.exception.AuthErrorCode.UNSUPPORTED_JWT;
 
 import com.sparta.moim.user.application.exception.JwtAuthenticationException;
+import com.sparta.moim.user.constants.JwtConstants.Claim;
+import com.sparta.moim.user.constants.JwtConstants.CookieName;
+import com.sparta.moim.user.constants.JwtConstants.Expiry;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -25,8 +28,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JwtUtil {
-  public static final int ACCESS_TOKEN_EXPIRY_SECOND = 60 * 30;
-  public static final int REFRESH_TOKEN_EXPIRY_SECOND = 60 * 60 * 24 * 7;
 
   private final SecretKey secretKey;
   private final String issuer;
@@ -39,9 +40,10 @@ public class JwtUtil {
     this.issuer = issuer;
   }
 
-  public String createAccessToken(String username, String role, UUID trackingId, ZonedDateTime now) {
-    Date expiration = Date.from(now.plusSeconds(ACCESS_TOKEN_EXPIRY_SECOND).toInstant());
+  public String createAccessToken(String username, UUID trackingId, UUID jti, ZonedDateTime now) {
+    Date expiration = Date.from(now.plusSeconds(Expiry.ACCESS_TOKEN).toInstant());
     return Jwts.builder()
+        .setId(jti.toString())
         .setSubject(trackingId.toString())
         .claim("username", username)
         .setIssuer(issuer)
@@ -51,11 +53,12 @@ public class JwtUtil {
         .compact();
   }
 
-  public String createRefreshToken(String username, UUID trackingId, ZonedDateTime now) {
-    Date expiration = Date.from(now.plusSeconds(REFRESH_TOKEN_EXPIRY_SECOND).toInstant());
+  public String createRefreshToken(String username, UUID trackingId, UUID jti, ZonedDateTime now) {
+    Date expiration = Date.from(now.plusSeconds(Expiry.REFRESH_TOKEN).toInstant());
     return Jwts.builder()
+        .setId(jti.toString())
         .setSubject(trackingId.toString())
-        .claim("username", username)
+        .claim(Claim.USERNAME, username)
         .setIssuer(issuer)
         .setIssuedAt(Date.from(now.toInstant()))
         .setExpiration(expiration)
@@ -86,22 +89,22 @@ public class JwtUtil {
   }
 
   public ResponseCookie createRefreshTokenCookie(String refreshToken) {
-    return ResponseCookie.from("refreshToken", refreshToken)
-        .path("/api/v1/auth/refresh")
+    return ResponseCookie.from(CookieName.REFRESH_TOKEN, refreshToken)
+        .path("/")
         .httpOnly(true)
         .secure(true)
         .sameSite(SameSite.STRICT.name())
-        .maxAge(JwtUtil.REFRESH_TOKEN_EXPIRY_SECOND)
+        .maxAge(Expiry.REFRESH_TOKEN)
         .build();
   }
 
   public ResponseCookie createAccessTokenCookie(String accessToken) {
-    return ResponseCookie.from("accessToken", accessToken)
+    return ResponseCookie.from(CookieName.ACCESS_TOKEN, accessToken)
         .path("/")
         .httpOnly(true)
         .secure(true)
         .sameSite(SameSite.LAX.name())
-        .maxAge(JwtUtil.ACCESS_TOKEN_EXPIRY_SECOND)
+        .maxAge(Expiry.ACCESS_TOKEN)
         .build();
   }
 }

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/redis/model/RefreshToken.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/redis/model/RefreshToken.java
@@ -1,0 +1,21 @@
+package com.sparta.moim.user.infrastructure.redis.model;
+
+import com.sparta.moim.user.constants.JwtConstants.Expiry;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@RedisHash(value = "refresh_token", timeToLive = Expiry.REFRESH_TOKEN)
+public class RefreshToken {
+
+  @Id
+  private String id;
+
+}

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/redis/repository/RefreshTokenRepository.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/redis/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.moim.user.infrastructure.redis.repository;
+
+import com.sparta.moim.user.infrastructure.redis.model.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+}

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/SecurityConfig.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/SecurityConfig.java
@@ -2,12 +2,14 @@ package com.sparta.moim.user.infrastructure.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.moim.common.security.filter.GlobalSecurityContextFilter;
-import com.sparta.moim.user.domain.repository.UserRepository;
+import com.sparta.moim.user.domain.UserRepository;
 import com.sparta.moim.user.infrastructure.jwt.JwtUtil;
+import com.sparta.moim.user.infrastructure.redis.repository.RefreshTokenRepository;
 import com.sparta.moim.user.infrastructure.security.filter.LoginFilter;
 import com.sparta.moim.user.infrastructure.security.handler.CustomLogoutSuccessHandler;
 import com.sparta.moim.user.infrastructure.security.handler.LoginFailureHandler;
 import com.sparta.moim.user.infrastructure.security.handler.LoginSuccessHandler;
+import com.sparta.moim.user.infrastructure.security.handler.TokenClearingLogoutHandler;
 import com.sparta.moim.user.infrastructure.service.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -36,6 +38,7 @@ public class SecurityConfig {
   private final ObjectMapper objectMapper;
   private final JwtUtil jwtUtil;
   private final GlobalSecurityContextFilter globalSecurityContextFilter;
+  private final RefreshTokenRepository refreshTokenRepository;
   private final UserRepository userRepository;
 
   private final AntPathRequestMatcher loginMatcher = new AntPathRequestMatcher(
@@ -55,7 +58,8 @@ public class SecurityConfig {
             (configurer) -> configurer
                 .logoutRequestMatcher(logoutMatcher)
                 .deleteCookies("accessToken", "refreshToken")
-                .logoutSuccessHandler(new CustomLogoutSuccessHandler()))
+                .logoutSuccessHandler(logoutSuccessHandler())
+                .addLogoutHandler(tokenClearingLogoutHandler()))
         .authorizeHttpRequests(auth -> auth.requestMatchers(
             "/api/v1/users/**", "/api/v1/auth/**", "/internal/v1/users/**").permitAll().anyRequest().authenticated())
         .sessionManagement(session -> session
@@ -86,8 +90,18 @@ public class SecurityConfig {
   @Bean
   public LoginFilter loginFilter() {
     LoginFilter loginFilter = new LoginFilter(loginMatcher, authenticationManager(), objectMapper);
-    loginFilter.setAuthenticationSuccessHandler(new LoginSuccessHandler(jwtUtil));
+    loginFilter.setAuthenticationSuccessHandler(new LoginSuccessHandler(jwtUtil, refreshTokenRepository));
     loginFilter.setAuthenticationFailureHandler(new LoginFailureHandler(objectMapper));
     return loginFilter;
+  }
+
+  @Bean
+  public CustomLogoutSuccessHandler logoutSuccessHandler() {
+    return new CustomLogoutSuccessHandler();
+  }
+
+  @Bean
+  public TokenClearingLogoutHandler tokenClearingLogoutHandler() {
+    return new TokenClearingLogoutHandler(jwtUtil, refreshTokenRepository);
   }
 }

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/handler/LoginSuccessHandler.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/handler/LoginSuccessHandler.java
@@ -1,6 +1,8 @@
 package com.sparta.moim.user.infrastructure.security.handler;
 
 import com.sparta.moim.user.infrastructure.jwt.JwtUtil;
+import com.sparta.moim.user.infrastructure.redis.model.RefreshToken;
+import com.sparta.moim.user.infrastructure.redis.repository.RefreshTokenRepository;
 import com.sparta.moim.user.infrastructure.service.CustomUserDetails;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +23,7 @@ import org.springframework.security.web.authentication.AuthenticationSuccessHand
 public class LoginSuccessHandler implements AuthenticationSuccessHandler {
 
   private final JwtUtil jwtUtil;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -29,16 +32,22 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
     CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
     String username = userDetails.getUsername();
     UUID trackingId = userDetails.getTrackingId();
-    String role = userDetails.getRole();
 
     ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
-    String accessToken = jwtUtil.createAccessToken(username, role, trackingId, now);
-    String refreshToken = jwtUtil.createRefreshToken(username, trackingId, now);
+
+    UUID accessTokenId = UUID.randomUUID();
+    String accessToken = jwtUtil.createAccessToken(username, trackingId, accessTokenId, now);
+
+    UUID refreshTokenId = UUID.randomUUID();
+    String refreshToken = jwtUtil.createRefreshToken(username, trackingId, refreshTokenId, now);
     log.info("Successfully create token");
 
     ResponseCookie accessTokenCookie = jwtUtil.createAccessTokenCookie(accessToken);
     ResponseCookie refreshTokenCookie = jwtUtil.createRefreshTokenCookie(refreshToken);
     log.info("Successfully create token cookie");
+
+    refreshTokenRepository.save(new RefreshToken(refreshTokenId.toString()));
+    log.info("Successfully save token storage");
 
     response.addHeader(HttpHeaders.SET_COOKIE, accessTokenCookie.toString());
     response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/handler/TokenClearingLogoutHandler.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/security/handler/TokenClearingLogoutHandler.java
@@ -1,0 +1,44 @@
+package com.sparta.moim.user.infrastructure.security.handler;
+
+import com.sparta.moim.user.constants.JwtConstants.CookieName;
+import com.sparta.moim.user.infrastructure.jwt.JwtUtil;
+import com.sparta.moim.user.infrastructure.redis.repository.RefreshTokenRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TokenClearingLogoutHandler implements LogoutHandler {
+
+  private final JwtUtil jwtUtil;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Override
+  public void logout(HttpServletRequest request, HttpServletResponse response,
+                     Authentication authentication) {
+    log.info("로그아웃 중: 토큰 클리어링 작업 시작");
+
+    String refreshToken = null;
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if (CookieName.REFRESH_TOKEN.equals(cookie.getName())) {
+          refreshToken = cookie.getValue();
+          break;
+        }
+      }
+    }
+
+    if (refreshToken != null) {
+      Claims claims = jwtUtil.extractClaims(refreshToken);
+      String jti = claims.getId();
+      refreshTokenRepository.deleteById(jti);
+      log.info("로그아웃 중: 저장된 리프래시 토큰 삭제 완료");
+    }
+  }
+}

--- a/user-service/src/main/java/com/sparta/moim/user/infrastructure/service/CustomUserDetailsService.java
+++ b/user-service/src/main/java/com/sparta/moim/user/infrastructure/service/CustomUserDetailsService.java
@@ -1,7 +1,7 @@
 package com.sparta.moim.user.infrastructure.service;
 
 import com.sparta.moim.user.domain.model.User;
-import com.sparta.moim.user.domain.repository.UserRepository;
+import com.sparta.moim.user.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: user-service
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
   datasource:
     url: jdbc:mysql://localhost:3308/user_db

--- a/user-service/src/test/java/com/sparta/moim/user/domain/repository/UserRepositoryTest.java
+++ b/user-service/src/test/java/com/sparta/moim/user/domain/repository/UserRepositoryTest.java
@@ -2,6 +2,7 @@ package com.sparta.moim.user.domain.repository;
 
 import com.sparta.moim.common.config.JpaConfig;
 import com.sparta.moim.user.domain.model.User;
+import com.sparta.moim.user.domain.UserRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/user-service/src/test/java/com/sparta/moim/user/integration/UserIntegrationTest.java
+++ b/user-service/src/test/java/com/sparta/moim/user/integration/UserIntegrationTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.moim.user.domain.model.User;
-import com.sparta.moim.user.domain.repository.UserRepository;
+import com.sparta.moim.user.domain.UserRepository;
 import com.sparta.moim.user.presentation.dto.LoginRequest;
 import com.sparta.moim.user.presentation.dto.SignupUserRequest;
 import jakarta.servlet.http.Cookie;


### PR DESCRIPTION
## 🚀 개요
- 토큰을 즉시 무효화 시키기 위해서는 리프래시 토큰을 서버에서 관리할 수 있어야합니다.
- 액세스 토큰을 같이 관리하는 방법도 있지만, 그렇게 되면 서버에서 관리하는 토큰의 양이 너무 많아짐에 따라 토큰 방식을 사용하는 이점이 없다고 판단했습니다.
- 다만, 이렇게 되면 액세스 토큰 같은 경우는 즉시 무효화를 못하기 때문에, 액세스 토큰이 탈취됐다고 가정 시, 액세스 토큰이 만료될 때까지 해커를 억제할 수 없습니다.
- 이에 대해서는 액세스 토큰을 발급할 때 최대한 안전하게 설정하는 것과, 해당 회원의 이상 행동(해커로 간주될 만한)이 감지되었을 떄 후처리를 하는 방식으로 진행이 필요합니다.
- 위에서 언급한 '최대한 안전하게 발급'의 예시로는 쿠키로 발급하거나, 만료 시간을 더 짧게 가져가는 등이 존재할 것 같습니다.

## 📝 작업 내용
### 1️⃣ 변경 사항
- 리프래시 토큰을 저장해놓을 DB를 Redis로 선택하였습니다.
- 이유는 이미 Redis를 사용하고 있었고, 가볍다는 점과 TTL을 설정할 수 있다는 점에서 선택하였습니다.
- 복잡한 데이터가 아니기 때문에 `RedisTemplate`이 아닌 `@RedisHash`와 `CrudRepository`를 사용하였습니다.
- 로그아웃 시 액세스 토큰 & 리프래시 토큰의 maxAge를 0으로 변경하고, Redis에서 리프래시 토큰을 삭제합니다.
- 이번 변경사항 이전에는 리프래시 토큰 쿠키의 path를 `재발급 url`에 대해서만 설정했는데, 로그아웃 시에도 리프래시 토큰이 필요했기 떄문에 "/" 로 변경해주었습니다. 이로써 path가 외부에 노출되지 않는다는 장점도 챙길 수 있지만 모든 요청에 대해 리프래시 토큰 쿠키가 포함되어 요청되기 때문에 보안 측면으로 단점이 생깁니다.

### 2️⃣ 변경 이유
- 서버에서 리프래시 토큰을 즉시 무효화하기 위함

### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.