### PR TITLE
[ Eureka] fix : 쌍따음표 제거

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,4 +18,4 @@ echo "[entrypoint] ECS_INSTANCE_IP_ADDRESS resolved as: $ECS_INSTANCE_IP_ADDRESS
 echo "[entrypoint] JAVA_OPTS: $JAVA_OPTS"
 
 # Spring Boot JAR 실행
-exec java "$JAVA_OPTS" -jar /app.jar
+exec java $JAVA_OPTS -jar /app.jar


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
eureka-service라는 클래스 이름을 실행하려다가 실패한 거야.
즉, -jar 방식이 아니라 클래스 실행 방식으로 오작동

Error: Could not find or load main class eureka-service
Caused by: java.lang.ClassNotFoundException: eureka-service
→ 이건 자바가 eureka-service라는 클래스 이름을 실행하려다가 실패한 거야.
즉, -jar 방식이 아니라 클래스 실행 방식으로 오작동한 거지.

$JAVA_OPTS" 대신 $JAVA_OPTS만 써줘야
옵션이 정상적으로 쪼개져서 전달됨
### 2️⃣ 변경 이유


### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Spring Boot 애플리케이션 실행 시 JAVA_OPTS 처리 방식을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->