### PR TITLE
[ Organization ] 모임 멤버 리스트 조회시 userTrackingId return

### DIFF
--- a/organization-service/src/main/java/com/sparta/moim/organization/application/dto/query/GetOrganizationMemberQuery.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/application/dto/query/GetOrganizationMemberQuery.java
@@ -11,12 +11,14 @@ public class GetOrganizationMemberQuery {
     private String memberTrackingId;
     private String nickname;;
     private String organizationRole;
+    private String userTrackingId;
 
     public static GetOrganizationMemberQuery from(OrganizationMember organizationMember){
         return GetOrganizationMemberQuery.builder()
                 .memberTrackingId(organizationMember.getTrackingId().toString())
                 .nickname(organizationMember.getNickname())
                 .organizationRole(organizationMember.getRole().toString())
+                .userTrackingId(organizationMember.getUserTrackingId().toString())
                 .build();
     }
 }

--- a/organization-service/src/main/java/com/sparta/moim/organization/presentation/dto/GetOrganizationMemberResponse.java
+++ b/organization-service/src/main/java/com/sparta/moim/organization/presentation/dto/GetOrganizationMemberResponse.java
@@ -9,4 +9,5 @@ public class GetOrganizationMemberResponse {
     private String memberTrackingId;
     private String nickname;
     private String organizationRole;
+    private String userTrackingId;
 }


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
모임 멤버들 조회시 userTrackingId도 함께 return 하도록 수정

### 2️⃣ 변경 이유


### 3️⃣ 추가 설명

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 조직 멤버 정보에 사용자 추적 ID(userTrackingId) 항목이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->