### PR TITLE
[Session] 매니저 이상이 세션을 생성하는 경우에는 바로 OPEN되도록 변경

### DIFF
--- a/session-service/src/main/java/com/sparta/moim/session/session/application/dto/command/CreateSessionCommand.java
+++ b/session-service/src/main/java/com/sparta/moim/session/session/application/dto/command/CreateSessionCommand.java
@@ -19,18 +19,18 @@ public record CreateSessionCommand(
     UUID userId,
     String role
 ) {
-  public Session toDomain() {
+  public Session toDomain(String reason, SessionStatus status) {
     return Session.builder()
         .organizationId(organizationId)
         .title(title)
         .totalCount(totalCount)
-        .status(SessionStatus.valueOf(status))
+        .status(status != null ? status : SessionStatus.valueOf(this.status))
         .openTime(openTime)
         .currentCount(1)
         .closeTime(closeTime)
         .applyTime(LocalDateTime.now())
         .confirmTime(role.equals("USER") ? null : LocalDateTime.now())
-        .reason(reason)
+        .reason(reason != null ? reason : this.reason)
         .publisher(publisher)
         .build();
   }

--- a/session-service/src/main/java/com/sparta/moim/session/session/application/dto/result/CreateManagerResult.java
+++ b/session-service/src/main/java/com/sparta/moim/session/session/application/dto/result/CreateManagerResult.java
@@ -1,0 +1,6 @@
+package com.sparta.moim.session.session.application.dto.result;
+
+import com.sparta.moim.session.shared.enums.SessionStatus;
+
+public record CreateManagerResult(String reason, SessionStatus status) {
+}

--- a/session-service/src/main/java/com/sparta/moim/session/session/application/service/SessionService.java
+++ b/session-service/src/main/java/com/sparta/moim/session/session/application/service/SessionService.java
@@ -8,6 +8,7 @@ import com.sparta.moim.session.session.application.dto.command.CreateSessionComm
 import com.sparta.moim.session.session.application.dto.command.SearchSessionCommand;
 import com.sparta.moim.session.session.application.dto.command.UpdateSessionCommand;
 import com.sparta.moim.session.session.application.dto.command.UpdateStateStateCommand;
+import com.sparta.moim.session.session.application.dto.result.CreateManagerResult;
 import com.sparta.moim.session.session.application.dto.result.CreateSessionResult;
 import com.sparta.moim.session.session.application.dto.result.GetSessionMemberListResult;
 import com.sparta.moim.session.session.application.dto.result.GetSessionResult;
@@ -48,16 +49,17 @@ public class SessionService {
       throw new SessionException(SessionCode.EXITS_TITLE_SESSION);
     }
 
-    Session createSession = sessionRepository.save(command.toDomain());
-    isCreateManager(command.userId(), createSession);
+    CreateManagerResult createManager = isCreateManager(command.userId(), command);
+    Session createSession = sessionRepository.save(command.toDomain(createManager.reason(), createManager.status()));
 
     createSession.timeValidate();
     addMemberPublisher.add(createSession.getTrackingId(), command.publisher());
     return CreateSessionResult.create(createSession);
   }
 
-  private void isCreateManager(UUID userId, Session createSession) {
-    ApiResponseData<Boolean> check = organizationSessionService.checkRole(createSession.getTrackingId(), userId,
+  private CreateManagerResult isCreateManager(UUID userId, CreateSessionCommand command) {
+    ApiResponseData<Boolean> check = organizationSessionService.checkRole(UUID.fromString(command.organizationId()),
+        userId,
         List.of(OrganizationMemberRole.MASTER,
             OrganizationMemberRole.MANAGER));
 
@@ -68,9 +70,10 @@ public class SessionService {
 
     // 매니저 이상이 생성한 경우
     if (check.getData()) {
-      createSession.createManger("매니저가 생성한 세션입니다.", SessionStatus.OPEN);
+      return new CreateManagerResult("매니저가 생성한 세션입니다.", SessionStatus.OPEN);
     }
 
+    return new CreateManagerResult(null, null);
   }
 
   @Transactional(readOnly = true)

--- a/session-service/src/main/java/com/sparta/moim/session/session/domain/entity/Session.java
+++ b/session-service/src/main/java/com/sparta/moim/session/session/domain/entity/Session.java
@@ -125,8 +125,4 @@ public class Session extends BaseEntity {
     this.currentCount = result;
   }
 
-  public void createManger(String reason, SessionStatus status) {
-    this.reason = reason;
-    this.status = status;
-  }
 }

--- a/session-service/src/main/java/com/sparta/moim/session/session/presentation/dto/request/CreateSessionRequest.java
+++ b/session-service/src/main/java/com/sparta/moim/session/session/presentation/dto/request/CreateSessionRequest.java
@@ -17,6 +17,10 @@ public record CreateSessionRequest(
     @NotNull LocalDateTime closeTime,
     CreateSessionApplyRequest applyInfo
 ) {
+  public CreateSessionRequest {
+    applyInfo = applyInfo == null ? new CreateSessionApplyRequest(null) : applyInfo;
+  }
+
   public CreateSessionCommand toCommand(UUID userId, String role) {
     return CreateSessionCommand.builder()
         .organizationId(organizationId)


### PR DESCRIPTION
## 🚀 개요
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 무엇을 수정했는지, 왜 수정했는지 간략하게 설명 -->

## 📝 작업 내용
### 1️⃣ 변경 사항
매니저 이상이 세션을 생성하여도 Ready가 되어지는 현상이 있었는데 바로 승인이 되도록 수정

### 2️⃣ 변경 이유


### 3️⃣ 추가 설명
- 추후 매니저가 생성하는 경우 기간에 따라 OPEN상태가 변경 고려
- 승인도 마찬가지 (대기일 필요)

## 💬 리뷰 요구사항

#### #️⃣ 연관된 이슈
closed #<이슈 번호>

## PR 유형

이 PR은 어떤 변경 사항을 포함하고 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경 (CSS 등)
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경 등)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 또는 폴더명 수정
- [ ] 파일 또는 폴더 삭제
- [ ] 배포 준비, PR 관련 사항

## ✅ Check List

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트)
- [ ] CI/CD 파이프라인을 통과했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 매니저 생성 결과를 위한 데이터 구조가 추가되었습니다.

- **버그 수정**
    - 세션 생성 요청 시 내부 필드가 항상 null이 아니도록 기본값이 자동으로 설정됩니다.

- **기능 개선**
    - 세션 생성 시 사용자의 역할(매니저 이상) 확인 및 세션 상태와 사유가 보다 명확하게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->